### PR TITLE
[optgrowth_fast] fix broken links

### DIFF
--- a/lectures/optgrowth_fast.md
+++ b/lectures/optgrowth_fast.md
@@ -346,8 +346,8 @@ ax.legend(loc='lower right')
 plt.show()
 ```
 
-This matches the solution that we obtained in our non-jitted code, {ref}`in
-the exercises <ogex1>`.
+This matches the solution that we obtained in our non-jitted code,
+{ref}`in the exercises <ogex1>`.
 
 Execution time is an order of magnitude faster.
 


### PR DESCRIPTION
fixes #25 

the `role` was split across two lines. 
