### PR TITLE
[download notebooks] Updates to support Download Notebooks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,11 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
+          zip -r download-notebooks.zip _build/jupyter
+      - uses: actions/upload-artifact@v2
+        with:
+          name: download-notebooks
+          path: download-notebooks.zip
       - name: Copy Download Notebooks for GH-PAGES
         shell: bash -l {0}
         run: |
@@ -48,6 +53,7 @@ jobs:
       #   run: |
       #     mkdir -p _build/lecture-python.notebooks
       #     cp -a _notebook_repo/. _build/lecture-python.notebooks
+      #     cp environment.yml _build/lecture-python.notebooks
       #     cp _build/jupyter/*.ipynb _build/lecture-python.notebooks
       #     ls -a _build/lecture-python.notebooks
       # - name: Commit latest notebooks to lecture-python.notebooks

--- a/_notebook_repo/README.md
+++ b/_notebook_repo/README.md
@@ -1,0 +1,7 @@
+# lecture-python.notebooks
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantEcon/lecture-python.notebooks/master)
+
+Notebooks for https://python.quantecon.org
+
+**Note:** This README should be edited [here](https://github.com/quantecon/lecture-python.myst/_notebook_repo)

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,5 @@ dependencies:
     - sphinx-exercise
     - joblib
     - interpolation
-    - sphinx-tojupyter
+    - git+https://github.com/quantecon/sphinx-tojupyter
 


### PR DESCRIPTION
This PR:

- [x] saves the download notebook collection as a build artifact
- [ ] enables syncing of download notebooks to `lecture-python.notebooks` (for deployment) [opening an issue to track this part] https://github.com/QuantEcon/lecture-python.myst/issues/107