### PR TITLE
Math code fixes making it compatible for latex

### DIFF
--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -116,10 +116,8 @@ $$
 Using the laws of probability, we can always factor such a joint density into a product of conditional densities:
 
 $$
-\begin{align}
   p(W_T, W_{T-1}, \ldots, W_1, W_0)    = & p(W_T | W_{t-1}, \ldots, W_0) p(W_{T-1} | W_{T-2}, \ldots, W_0) \cdots  \cr
   & p(W_1 | W_0) p(W_0)
-\end{align}
 $$
 
 In general,

--- a/lectures/lq_inventories.md
+++ b/lectures/lq_inventories.md
@@ -140,8 +140,6 @@ To form the matrices $R, Q, H$, we note that the firm’s profits at
 time $t$ function can be expressed
 
 $$
-\begin{equation}
-\begin{split}
 \pi_{t} =&p_{t}S_{t}-c\left(Q_{t}\right)-d\left(I_{t},S_{t}\right)  \\
     =&\left(a_{0}-a_{1}S_{t}+v_{t}\right)S_{t}-c_{1}Q_{t}-c_{2}Q_{t}^{2}-d_{1}I_{t}-d_{2}\left(S_{t}-I_{t}\right)^{2}  \\
     =&a_{0}S_{t}-a_{1}S_{t}^{2}+Gz_{t}S_{t}-c_{1}Q_{t}-c_{2}Q_{t}^{2}-d_{1}I_{t}-d_{2}S_{t}^{2}-d_{2}I_{t}^{2}+2d_{2}S_{t}I_{t}  \\
@@ -168,8 +166,6 @@ Q_{t} & S_{t}\end{array}\right]\underset{\equiv N}{\underbrace{\left[\begin{arra
 I_{t}\\
 z_{t}
 \end{array}\right]\right)
-\end{split}
-\end{equation}
 $$
 
 where $S_{c}=\left[1,0\right]$.

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -33,7 +33,7 @@ In this lecture, you will learn formulas for
 
 * the joint distribution of a random vector $x$ of length $N$
 * marginal distributions for all subvectors of $x$
-* conditional distributions for subvectors of 'math:x conditional on other subvectors of $x$
+* conditional distributions for subvectors of $x$ conditional on other subvectors of $x$
 
 We will use  the multivariate normal distribution to formulate some classic models:
 


### PR DESCRIPTION
`begin{align}`, `begin{equation}`, `begin{split}` is unnecessary inside $$ math environment, and breaks latex builds.