### PR TITLE
[05_complex_and_trig] Fix SymPyDepreciationWarning (Issue58)

### DIFF
--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -310,7 +310,7 @@ eq1 = Eq(x1/x0 - r * cos(ω+θ) / cos(ω), 0)
 print(f'ω = {ω:1.3f}')
 
 # Solve for p
-eq2 = Eq(x0 - 2 * p * cos(ω))
+eq2 = Eq(x0 - 2 * p * cos(ω), 0)
 p = nsolve(eq2, p, 0)
 p = np.float(p)
 print(f'p = {p:1.3f}')


### PR DESCRIPTION
Hi @mmcky and @jstac , as discussed with @mmcky , this PR fix #58 by 
- changing code ``eq2 = Eq(x0 - 2 * p * cos(ω))`` to ``eq2 = Eq(x0 - 2 * p * cos(ω), 0)`` in lecture [complex_and_trig](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/complex_and_trig.md).