### PR TITLE
[22_cass_koopmans_2] Fix SyntaxWarning

### DIFF
--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -835,9 +835,9 @@ for T in T_arr:
     for i, ax in enumerate(axs.flatten()):
         ax.plot(paths[i])
         ax.set(title=titles[i], ylabel=ylabels[i], xlabel='t')
-        if titles[i] is 'Capital':
+        if titles[i] == 'Capital':
             ax.axhline(k_ss, lw=1, ls='--', c='k')
-        if titles[i] is 'Consumption':
+        if titles[i] == 'Consumption':
             ax.axhline(c_ss, lw=1, ls='--', c='k')
 
 plt.tight_layout()


### PR DESCRIPTION
Hi @mmcky , this PR fix #62 by 
- changing ``is`` to ``==`` in lecture [cass_koopmans_2](https://quantecon.github.io/lecture-python.myst/cass_koopmans_2.html)
