### PR TITLE
Remove only html and latex directives for common markdown source

### DIFF
--- a/lectures/aiyagari.md
+++ b/lectures/aiyagari.md
@@ -37,13 +37,7 @@ tags: [hide-output]
 
 In this lecture, we describe the structure of a class of models that build on work by Truman Bewley {cite}`Bewley1977`.
 
-```{only} html
-We begin by discussing an example of a Bewley model due to <a href=_static/lecture_specific/aiyagari/aiyagari_obit.pdf download>Rao Aiyagari</a>.
-```
-
-```{only} latex
 We begin by discussing an example of a Bewley model due to [Rao Aiyagari](https://lectures.quantecon.org/_downloads/aiyagari_obit.pdf).
-```
 
 The model features
 

--- a/lectures/linear_algebra.md
+++ b/lectures/linear_algebra.md
@@ -837,15 +837,7 @@ $x$ that makes the distance $\| y - Ax\|$ as small as possible.
 To solve this problem, one can use either calculus or the theory of orthogonal
 projections.
 
-```{only} html
-The solution is known to be $\hat x = (A'A)^{-1}A'y$ --- see for example
-chapter 3 of <a href=_static/lecture_specific/linear_algebra/course_notes.pdf download>these notes</a>.
-```
-
-```{only} latex
-The solution is known to be $\hat x = (A'A)^{-1}A'y$ --- see for example
-chapter 3 of [these notes](https://lectures.quantecon.org/_downloads/course_notes.pdf).
-```
+The solution is known to be $\hat x = (A'A)^{-1}A'y$ --- see for example chapter 3 of [these notes](https://lectures.quantecon.org/_downloads/course_notes.pdf).
 
 ### More Columns than Rows
 

--- a/lectures/linear_models.md
+++ b/lectures/linear_models.md
@@ -1041,13 +1041,7 @@ $$
 
 regardless of the initial conditions $\mu_0$ and $\Sigma_0$.
 
-```{only} html
-This is the *globally stable case* --- see <a href=_static/lecture_specific/linear_models/iteration_notes.pdf download>these notes</a> for more a theoretical treatment.
-```
-
-```{only} latex
 This is the *globally stable case* --- see [these notes](https://lectures.quantecon.org/_downloads/iteration_notes.pdf) for more a theoretical treatment.
-```
 
 However, global stability is more than we need for stationary solutions, and often more than we want.
 

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -134,15 +134,8 @@ Let's have a look at the distribution of the data we'll be working with in this 
 
 Treisman's main source of data is *Forbes'* annual rankings of billionaires and their estimated net worth.
 
-```{only} html
-The dataset `mle/fp.dta` can be downloaded <a href=/_static/lecture_specific/mle/fp.dta download>here</a>
-or from its [AER page](https://www.aeaweb.org/articles?id=10.1257/aer.p20161068).
-```
-
-```{only} latex
 The dataset `mle/fp.dta` can be downloaded from [here](https://lectures.quantecon.org/_downloads/mle/fp.dta)
 or its [AER page](https://www.aeaweb.org/articles?id=10.1257/aer.p20161068).
-```
 
 ```{code-cell} python3
 pd.options.display.max_columns = 10


### PR DESCRIPTION
As discussed with @mmcky , I create this PR to fix issue #57 by removing the ``only`` directives with unified markdown syntax in the following lectures:
- [aiyagari](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/aiyagari.md),
- [linear_algebra](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/linear_algebra.md),
- [linear_models](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/linear_models.md),
- [mle](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/mle.md)