### PR TITLE
ENH: enable cached build folders using artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           workflow: publish.yml
           branch: main
           name: build-cache
+          path: _build
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
         shell: bash -l {0}
         run: pip list
       - name: Download "build" folder (cache)
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: publish.yml
+          branch: main
           name: build-cache
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
           branch: main
           name: build-cache
           path: _build
-      - name: Check Build Folder
-        shell: bash -l {0}
-        run: ls -a
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download "build" folder (cache)
         uses: actions/download-artifact@v2
         with:
-          name: build-folder
+          name: build-cache
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           branch: main
           name: build-cache
           path: _build
+      - name: Check Build Folder
+        shell: bash -l {0}
+        run: ls -a
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
+      - name: Download "build" folder (cache)
+        uses: actions/download-artifact@v2
+        with:
+          name: build-folder
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
+      - name: Download "build" folder (cache)
+        uses: actions/download-artifact@v2
+        with:
+          name: build-cache
       - name: Build HTML
         shell: bash -l {0}
         run: |
@@ -46,7 +50,7 @@ jobs:
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v2
         with:
-          name: build-folder
+          name: build-cache
           path: _build
       # - name: Prepare lecture-python.notebooks sync
       #   shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html/
           # cname: python.quantecon.org
+      - name: Upload "_build" folder (cache)
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-folder
+          path: _build
       # - name: Prepare lecture-python.notebooks sync
       #   shell: bash -l {0}
       #   run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: actions/download-artifact@v2
-        with:
-          name: build-cache
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,11 +43,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html/
           # cname: python.quantecon.org
-      - name: Upload "_build" folder (cache)
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-cache
-          path: _build
       # - name: Prepare lecture-python.notebooks sync
       #   shell: bash -l {0}
       #   run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+lectures/_build


### PR DESCRIPTION
This PR fixes #12 by using `build` artifacts from the `publish.yml` process. 

- [x] add use of `cached build` folder for PRs
- [ ] add use of `cached build` folder for publishing with `_build` folder updating

Not going to implement the second as it is more risky given it is on the `publishing` pathway. We can add this at a later date.

