### PR TITLE
🐛 FIX: Math env syntax issue

### DIFF
--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -116,10 +116,10 @@ $$
 Using the laws of probability, we can always factor such a joint density into a product of conditional densities:
 
 $$
-\begin{align}
+\begin{aligned}
   p(W_T, W_{T-1}, \ldots, W_1, W_0)    = & p(W_T | W_{T-1}, \ldots, W_0) p(W_{T-1} | W_{T-2}, \ldots, W_0) \cdots  \cr
   & \quad \quad \cdots p(W_1 | W_0) p(W_0)
-\end{align}
+\end{aligned}
 $$
 
 In general,

--- a/lectures/lq_inventories.md
+++ b/lectures/lq_inventories.md
@@ -140,7 +140,6 @@ $$
 To form the matrices $R, Q, N$ in an LQ dynamic programming problem, we note that the firm’s profits at
 time $t$ function can be expressed
 
-$$
 \begin{equation}
 \begin{split}
 \pi_{t} =&p_{t}S_{t}-c\left(Q_{t}\right)-d\left(I_{t},S_{t}\right)  \\
@@ -172,7 +171,6 @@ z_{t}
 \end{array}\right]\right)
 \end{split}
 \end{equation}
-$$
 
 where $S_{c}=\left[1,0\right]$.
 


### PR DESCRIPTION
fixes https://github.com/QuantEcon/lecture-python.myst/issues/102

@mmcky only a few changes needed. rest seems ok.