### PR TITLE
Update Rendering Priorities to promote LaTeX outputs

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -16,6 +16,17 @@ html:
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter]
   config:
+    nb_render_priority:
+      html:
+      - "application/vnd.jupyter.widget-view+json"
+      - "application/javascript"
+      - "text/html"
+      - "text/latex"
+      - "image/svg+xml"
+      - "image/png"
+      - "image/jpeg"
+      - "text/markdown"
+      - "text/plain"
     html_favicon: _static/lectures-favicon.ico
     html_theme: quantecon_book_theme
     html_static_path: ['_static']


### PR DESCRIPTION
This PR fixes #38 by promoting `latex` as a preferred output type for rendering by `mathjax`

