### PR TITLE
[all] Adopt standard figsize for quantecon-book-theme

### DIFF
--- a/lectures/aiyagari.md
+++ b/lectures/aiyagari.md
@@ -55,10 +55,11 @@ The Aiyagari model has been used to investigate many topics, including
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon.markov import DiscreteDP
 from numba import jit
 ```

--- a/lectures/ar1_processes.md
+++ b/lectures/ar1_processes.md
@@ -47,8 +47,9 @@ Let's start with some imports:
 
 ```{code-cell} ipython
 import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 ```
 
 ## The AR(1) Model

--- a/lectures/cake_eating_numerical.md
+++ b/lectures/cake_eating_numerical.md
@@ -46,10 +46,10 @@ accuracy of alternative numerical methods.
 We will use the following imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from interpolation import interp
 from scipy.optimize import minimize_scalar, bisect
 ```

--- a/lectures/cake_eating_problem.md
+++ b/lectures/cake_eating_problem.md
@@ -40,9 +40,10 @@ Readers might find it helpful to review the following lectures before reading th
 In what follows, we require the following imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 ```
 
 ## The Model

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -47,10 +47,11 @@ This exposition draws on the presentation in {cite}`Ljungqvist2012`, section 6.5
 We begin with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
 from numba import njit, prange
 from quantecon.distributions import BetaBinomial
 from scipy.special import binom, beta

--- a/lectures/cass_koopmans_1.md
+++ b/lectures/cass_koopmans_1.md
@@ -54,11 +54,12 @@ The lecture uses important ideas including
 Let's start with some standard imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, float64
 from numba.experimental import jitclass
 import numpy as np
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## The Model

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -66,11 +66,12 @@ The present lecture uses  additional  ideas including
 Let's start with some standard imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, float64
 from numba.experimental import jitclass
 import numpy as np
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Review of Cass-Koopmans Model

--- a/lectures/coleman_policy_iter.md
+++ b/lectures/coleman_policy_iter.md
@@ -61,11 +61,11 @@ iteration can be further adjusted to obtain even more efficiency.
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
-
 from interpolation import interp
 from quantecon.optimize import brentq
 from numba import njit, float64

--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -98,9 +98,10 @@ $$
 We'll need the following imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from sympy import *
 ```
 

--- a/lectures/egm_policy_iter.md
+++ b/lectures/egm_policy_iter.md
@@ -51,14 +51,15 @@ The original reference is {cite}`Carroll2006`.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
 from interpolation import interp
 from numba import njit, float64
 from numba.experimental import jitclass
 from quantecon.optimize import brentq
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Key Idea

--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -66,13 +66,14 @@ Let’s start with some imports:
 ---
 tags: [hide-output]
 ---
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, vectorize
 from math import gamma
 import scipy.optimize as op
 from scipy.integrate import quad
 import numpy as np
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Independently and Identically Distributed

--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -52,11 +52,12 @@ Prerequisite knowledge is basic probability and linear algebra.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import quantecon as qe
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Definitions

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -81,10 +81,11 @@ key ideas.
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 The following two lines can be added to avoid an annoying FutureWarning, and prevent a specific compatibility issue between pandas and matplotlib from causing problems down the line:

--- a/lectures/ifp.md
+++ b/lectures/ifp.md
@@ -59,13 +59,14 @@ Time iteration is globally convergent under mild assumptions, even when utility 
 We'll need the following imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from quantecon.optimize import brent_max, brentq
 from interpolation import interp
 from numba import njit, float64
 from numba.experimental import jitclass
-import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import MarkovChain
 ```
 

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -56,13 +56,14 @@ endogenous grid method to solve the model quickly and accurately.
 We require the following imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from quantecon.optimize import brent_max, brentq
 from interpolation import interp
 from numba import njit, float64
 from numba.experimental import jitclass
-import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import MarkovChain
 ```
 

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -47,10 +47,10 @@ While our Markov environment and many of the concepts we consider are related to
 Let's start with some imports
 
 ```{code-cell} ipython3
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from numba import njit, float64, prange
 from numba.experimental import jitclass
 ```

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -46,12 +46,13 @@ In this section, we solve a simple on-the-job search model
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import scipy.stats as stats
 from interpolation import interp
 from numba import njit, prange
-import matplotlib.pyplot as plt
-%matplotlib inline
 from math import gamma
 ```
 

--- a/lectures/kalman.md
+++ b/lectures/kalman.md
@@ -55,11 +55,12 @@ Required knowledge: Familiarity with matrix manipulations, multivariate normal d
 We'll need the following imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from scipy import linalg
 import numpy as np
 import matplotlib.cm as cm
-import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import Kalman, LinearStateSpace
 from scipy.stats import norm
 from scipy.integrate import quad

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -54,10 +54,10 @@ We will discuss these issues as we go along.
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 import quantecon as qe
 ```
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -68,10 +68,11 @@ These concepts will help us build an equilibrium model of ex-ante homogeneous wo
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from quantecon import MarkovChain
-import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.stats import norm
 from scipy.optimize import brentq
 from quantecon.distributions import BetaBinomial

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -25,11 +25,12 @@ kernelspec:
 ```
 
 ```{code-cell} ipython
-import numpy as np
+%matplotlib inline
 import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from numba import vectorize, njit
 from math import gamma
-%matplotlib inline
 ```
 
 ## Overview

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -25,11 +25,12 @@ kernelspec:
 ```
 
 ```{code-cell} ipython
-import numpy as np
+%matplotlib inline
 import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from numba import vectorize, njit
 from math import gamma
-%matplotlib inline
 from scipy.integrate import quad
 ```
 

--- a/lectures/linear_algebra.md
+++ b/lectures/linear_algebra.md
@@ -73,9 +73,10 @@ material that will be used in applications as we go along.
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from matplotlib import cm
 from mpl_toolkits.mplot3d import Axes3D
 from scipy.interpolate import interp2d

--- a/lectures/linear_models.md
+++ b/lectures/linear_models.md
@@ -66,9 +66,10 @@ Its many applications include:
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from quantecon import LinearStateSpace
 from scipy.stats import norm
 import random

--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -51,10 +51,11 @@ Some of these extensions are presented as exercises.
 We'll need the following imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import random
 import numpy as np
-import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.stats import t, beta, lognorm, expon, gamma, uniform, cauchy
 from scipy.stats import gaussian_kde, poisson, binom, norm, chi2
 from mpl_toolkits.mplot3d import Axes3D

--- a/lectures/lq_inventories.md
+++ b/lectures/lq_inventories.md
@@ -203,10 +203,11 @@ Here is code for computing an optimal decision rule and for analyzing
 its consequences.
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ```{code-cell} python3

--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -70,9 +70,10 @@ In order to focus on computation, we leave longer proofs to these sources (while
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from quantecon import LQ
 ```
 

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -71,9 +71,10 @@ Key tools for the lecture are
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 import quantecon as qe
 from numpy.linalg import eigvals, solve
 ```

--- a/lectures/markov_perf.md
+++ b/lectures/markov_perf.md
@@ -58,10 +58,11 @@ Other references include chapter 7 of {cite}`Ljungqvist2012`.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Background

--- a/lectures/mccall_correlated.md
+++ b/lectures/mccall_correlated.md
@@ -47,10 +47,10 @@ This is to keep the model relatively simple as we study the impact of correlatio
 We will use the following imports:
 
 ```{code-cell} ipython3
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 import quantecon as qe
 from interpolation import interp
 from numpy.random import randn

--- a/lectures/mccall_fitted_vfi.md
+++ b/lectures/mccall_fitted_vfi.md
@@ -58,10 +58,10 @@ Fitted VFI is very common in practice, so we will take some time to work through
 We will use the following imports:
 
 ```{code-cell} ipython3
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 import quantecon as qe
 from interpolation import interp
 from numpy.random import randn

--- a/lectures/mccall_model.md
+++ b/lectures/mccall_model.md
@@ -60,11 +60,12 @@ As we'll see, McCall's model is not only interesting in its own right but also a
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from numba import jit, float64
 from numba.experimental import jitclass
-import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 from quantecon.distributions import BetaBinomial
 ```

--- a/lectures/mccall_model_with_separation.md
+++ b/lectures/mccall_model_with_separation.md
@@ -55,10 +55,10 @@ worker preferences slightly more sophisticated.
 We'll need the following imports
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from numba import njit, float64
 from numba.experimental import jitclass
 from quantecon.distributions import BetaBinomial

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -43,10 +43,11 @@ economic factors such as market size and tax rate predict.
 We'll require the following imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from numpy import exp
-import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.special import factorial
 import pandas as pd
 from mpl_toolkits.mplot3d import Axes3D

--- a/lectures/multi_hyper.md
+++ b/lectures/multi_hyper.md
@@ -111,13 +111,14 @@ The right tool for the administrator's job is the **multivariate hypergeometric 
 Let's start with some imports.
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import matplotlib.cm as cm
 import numpy as np
 from scipy.special import comb
 from scipy.stats import normaltest
 from numba import njit, prange
-import matplotlib.pyplot as plt
-%matplotlib inline
-import matplotlib.cm as cm
 ```
 
 To recapitulate, we assume there are in total $c$ types of objects in an urn.

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -61,11 +61,12 @@ We apply our Python class to some classic examples.
 We will use the following imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from numba import njit
 import statsmodels.api as sm
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 Assume that an $N \times 1$ random vector $z$ has a

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -34,9 +34,10 @@ tags: [hide-output]
 ```
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from numba import njit, prange, float64, int64
 from numba.experimental import jitclass
 from interpolation import interp

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -58,12 +58,13 @@ must be learned.
 Let’s start with some imports
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, prange, vectorize
 from interpolation import mlinterp, interp
 from math import gamma
 import numpy as np
-import matplotlib.pyplot as plt
-%matplotlib inline
 from matplotlib import cm
 import scipy.optimize as op
 from scipy.stats import cumfreq, beta

--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -58,9 +58,10 @@ Such variation is needed to determine whether it is institutions that give rise 
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 from statsmodels.iolib.summary2 import summary_col

--- a/lectures/optgrowth.md
+++ b/lectures/optgrowth.md
@@ -60,12 +60,12 @@ techniques to drastically improve execution time over the next few lectures.
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
+%matplotlib inline
 import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from scipy.interpolate import interp1d
 from scipy.optimize import minimize_scalar
-
-%matplotlib inline
 ```
 
 ## The Model

--- a/lectures/optgrowth_fast.md
+++ b/lectures/optgrowth_fast.md
@@ -60,14 +60,14 @@ accelerate our code.
 Let's start with some imports:
 
 ```{code-cell} ipython
-import numpy as np
+%matplotlib inline
 import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 from interpolation import interp
 from numba import jit, njit, prange, float64, int32
 from numba.experimental import jitclass
 from quantecon.optimize.scalar_maximization import brent_max
-
-%matplotlib inline
 ```
 
 We are using an interpolation function from

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -361,8 +361,9 @@ Using this series, we can plot the average real minimum wage over the
 past decade for each country in our data set
 
 ```{code-cell} ipython
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import matplotlib
 matplotlib.style.use('seaborn')
 

--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -56,8 +56,9 @@ Background readings on the linear-quadratic-Gaussian permanent income model are 
 Let's start with some imports
 
 ```{code-cell} ipython
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import random
 from numba import njit

--- a/lectures/perm_income_cons.md
+++ b/lectures/perm_income_cons.md
@@ -75,11 +75,12 @@ The model will prove useful for illustrating concepts such as
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import quantecon as qe
 import numpy as np
 import scipy.linalg as la
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Setup

--- a/lectures/rational_expectations.md
+++ b/lectures/rational_expectations.md
@@ -66,9 +66,10 @@ Except that for us
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 ```
 
 We'll also use the LQ class from QuantEcon.py.

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -37,10 +37,11 @@ tags: [hide-output]
 ```
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import quantecon as qe
-import matplotlib.pyplot as plt
-%matplotlib inline
 from sympy import *
 init_printing()
 ```

--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -47,9 +47,10 @@ Our objectives are to
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 ```
 
 We'll also use the following for various tasks described below:

--- a/lectures/scalar_dynam.md
+++ b/lectures/scalar_dynam.md
@@ -37,9 +37,10 @@ intuition.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 ```
 
 ## Some Definitions

--- a/lectures/schelling.md
+++ b/lectures/schelling.md
@@ -47,10 +47,11 @@ In this lecture, we (in fact you) will build and run a version of Schelling's mo
 Let's start with some imports:
 
 ```{code-cell} ipython
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from random import uniform, seed
 from math import sqrt
-import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## The Model

--- a/lectures/sir_model.md
+++ b/lectures/sir_model.md
@@ -51,10 +51,11 @@ other countries.
 We will use the following standard imports:
 
 ```{code-cell} ipython3
+%matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from numpy import exp
-
-import matplotlib.pyplot as plt
 ```
 
 We will also use SciPy's numerical routine odeint for solving differential

--- a/lectures/time_series_with_matrices.md
+++ b/lectures/time_series_with_matrices.md
@@ -47,8 +47,9 @@ We will use the following imports:
 
 ```{code-cell} ipython
 import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 ```
 
 ## Samuelson's model

--- a/lectures/uncertainty_traps.md
+++ b/lectures/uncertainty_traps.md
@@ -51,8 +51,9 @@ Uncertainty traps stem from a positive externality: high aggregate economic acti
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-import matplotlib.pyplot as plt
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import itertools
 ```

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -71,10 +71,10 @@ At the same time, all of the techniques discussed here can be plugged into model
 We will use the following imports.
 
 ```{code-cell} ipython3
-import numpy as np
-import matplotlib.pyplot as plt
 %matplotlib inline
-
+import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
+import numpy as np
 import quantecon as qe
 from numba import njit, float64, prange
 from numba.experimental import jitclass


### PR DESCRIPTION
This PR adjust the `matplotlib` to be in line with the QuantEcon.manual recommendations

```
%matplotlib inline
import matplotlib.pyplot as plt
plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
```