### PR TITLE
PUBLISH: Setup for live publishing based on "publish*" tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,11 @@
-name: Build & Publish to GH Pages
+name: Build & Publish to GH-PAGES
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'publish*'
 jobs:
   publish:
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR changes the pathway for publishing to `gh-pages` using a tag based approach to trigger changes to be built for `gh-pages`. To setup an `automated` update to the live site you would need to create a `tag` with the `publish*` pattern such as `publish-2021mar16`