### PR TITLE
[Execution] publish execution statistics for website

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -93,3 +93,4 @@
   chapters:
     - file: troubleshooting
     - file: zreferences
+    - file: status

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -1,0 +1,20 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Execution Statistics
+
+This table contains the latest execution statistics.
+
+```{nb-exec-table}
+```
+
+These lectures are built on `linux` instances through `github actions` so are
+executed using the following [hardware specifications](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources)


### PR DESCRIPTION
This PR adds a page to publish the `execution` statistics. 

We will work on adding badges to each lecture as an extension. 