### PR TITLE
MAINT: revert back to pip installs using quantecon-book-theme=0.1.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book
     - sphinx-multitoc-numbering
-    - git+https://github.com/quantecon/quantecon-book-theme
+    - quantecon-book-theme
     - sphinx-tojupyter
     - sphinxext-rediraffe
     - sphinx-exercise

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book
     - sphinx-multitoc-numbering
-    - quantecon-book-theme=0.1.6
+    - quantecon-book-theme==0.1.6
     - sphinx-tojupyter
     - sphinxext-rediraffe
     - sphinx-exercise

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book
     - sphinx-multitoc-numbering
-    - quantecon-book-theme==0.1.6
+    - quantecon-book-theme
     - sphinx-tojupyter
     - sphinxext-rediraffe
     - sphinx-exercise

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book
     - sphinx-multitoc-numbering
-    - quantecon-book-theme
+    - quantecon-book-theme=0.1.6
     - sphinx-tojupyter
     - sphinxext-rediraffe
     - sphinx-exercise


### PR DESCRIPTION
`quantecon-book-theme=0.1.7` has now been released on PyPI