### PR TITLE
pin environment for upcoming major changes to jupyter-book

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,15 +6,15 @@ dependencies:
   - anaconda=2020.11
   - pip
   - pip:
-    - jupyter-book
-    - sphinx-multitoc-numbering
+    - jupyter-book==0.10.2
+    - sphinx-multitoc-numbering==0.1.3
     - quantecon-book-theme==0.1.7
-    - sphinx-tojupyter
-    - sphinxext-rediraffe
-    - sphinx-exercise
-    - jupytext
-    - ghp-import
-    - jupinx
+    - sphinx-tojupyter==0.1.1
+    - sphinxext-rediraffe==0.2.7
+    - sphinx-exercise==0.1.1
+    - jupytext==1.11.2
+    - ghp-import==1.1.0
+    - jupinx==0.2.3
     # Temporary Fixes
     - tornado>=6.1
 


### PR DESCRIPTION
This PR pins to the current versions of `jupyter-book` software stack for stability in publishing