### PR TITLE
[finite_markov] Remove redundant array creation

### DIFF
--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -1258,7 +1258,6 @@ p = β / (α + β)
 
 P = ((1 - α,       α),               # Careful: P and p are distinct
      (    β,   1 - β))
-P = np.array(P)
 mc = MarkovChain(P)
 
 fig, ax = plt.subplots(figsize=(9, 6))


### PR DESCRIPTION
Migrated from QuantEcon/lecture-python#382