### PR TITLE
[short_path] Define num_nodes in compute_to_go

### DIFF
--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -428,6 +428,7 @@ def bellman(J, Q):
 
 
 def compute_cost_to_go(Q):
+    num_nodes = Q.shape[0]
     J = np.zeros(num_nodes)      # Initial guess
     next_J = np.empty(num_nodes)  # Stores updated guess
     max_iter = 500


### PR DESCRIPTION
`num_nodes`  in the `compute_cost_to_go` function refers to that in the global scope, but it should be defined in the local scope. 