### PR TITLE
[short_path] Fix DeprecationWarning

### DIFF
--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -222,8 +222,8 @@ Let's try with this example and see how we go:
 
 ```{code-cell} python3
 nodes = range(7)                              # Nodes = 0, 1, ..., 6
-J = np.zeros_like(nodes, dtype=np.int)        # Initial guess
-next_J = np.empty_like(nodes, dtype=np.int)   # Stores updated guess
+J = np.zeros_like(nodes, dtype=int)        # Initial guess
+next_J = np.empty_like(nodes, dtype=int)   # Stores updated guess
 
 max_iter = 500
 i = 0


### PR DESCRIPTION
Fix the following warning.
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  J = np.zeros_like(nodes, dtype=np.int)
```
