### PR TITLE
np.ones * alpha -->> np.full

### DIFF
--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -120,8 +120,7 @@ $z = 1 + \sqrt{3} i$.
 ```{code-cell} python3
 # Abbreviate useful values and functions
 π = np.pi
-zeros = np.zeros
-ones = np.ones
+
 
 # Set parameters
 r = 2
@@ -135,9 +134,9 @@ fig = plt.figure(figsize=(8, 8))
 ax = plt.subplot(111, projection='polar')
 
 ax.plot((0, θ), (0, r), marker='o', color='b')          # Plot r
-ax.plot(zeros(x_range.shape), x_range, color='b')       # Plot x
+ax.plot(np.zeros(x_range.shape), x_range, color='b')       # Plot x
 ax.plot(θ_range, x / np.cos(θ_range), color='b')        # Plot y
-ax.plot(θ_range, ones(θ_range.shape) * 0.1, color='r')  # Plot θ
+ax.plot(θ_range, np.full(θ_range.shape, 0.1), color='r')  # Plot θ
 
 ax.margins(0) # Let the plot starts at origin
 

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -140,8 +140,8 @@ legend_args = {'ncol': 3,
                'mode': 'expand'}
 
 ax.plot(X, label="inventory")
-ax.plot(s * np.ones(sim_length), 'k--', label="$s$")
-ax.plot(S * np.ones(sim_length), 'k-', label="$S$")
+ax.plot(np.full(sim_length, s), 'k--', label="$s$")
+ax.plot(np.full(sim_length, S), 'k-', label="$S$")
 ax.set_ylim(0, S+10)
 ax.set_xlabel("time")
 ax.legend(**legend_args)
@@ -156,8 +156,8 @@ the probabilities of different outcomes:
 sim_length=200
 fig, ax = plt.subplots()
 
-ax.plot(s * np.ones(sim_length), 'k--', label="$s$")
-ax.plot(S * np.ones(sim_length), 'k-', label="$S$")
+ax.plot(np.full(sim_length, s), 'k--', label="$s$")
+ax.plot(np.full(sim_length, S), 'k-', label="$S$")
 ax.set_ylim(0, S+10)
 ax.legend(**legend_args)
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -265,7 +265,7 @@ class LakeModel:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = 0.5 * np.ones(2)
+        x = np.full(2, 0.5)
         error = tol + 1
         while error > tol:
             new_x = self.A_hat @ x
@@ -1049,7 +1049,7 @@ class LakeModelModified:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = 0.5 * np.ones(2)
+        x = np.full(2, 0.5)
         error = tol + 1
         while error > tol:
             new_x = self.A_hat @ x

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -923,7 +923,7 @@ Consider the following primitives
 ```{code-cell} python3
 n = 5
 P = np.full((n, n), 0.0125)
-P += np.diag(0.95 - 0.0125 * np.ones(5))
+P[range(n), range(n)] += 1 - P.sum(1)
 # State values of the Markov chain
 s = np.array([0.95, 0.975, 1.0, 1.025, 1.05])
 γ = 2.0
@@ -1011,7 +1011,7 @@ First, let's enter the parameters:
 ```{code-cell} python3
 n = 5
 P = np.full((n, n), 0.0125)
-P += np.diag(0.95 - 0.0125 * np.ones(5))
+P[range(n), range(n)] += 1 - P.sum(1)
 s = np.array([0.95, 0.975, 1.0, 1.025, 1.05])  # State values
 mc = qe.MarkovChain(P, state_values=s)
 

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -514,7 +514,7 @@ test scores $\sigma_{y}$.
 ```{code-cell} python3
 def construct_moments_IQ(n, μθ, σθ, σy):
 
-    μ_IQ = np.ones(n+1) * μθ
+    μ_IQ = np.full(n+1, μθ)
 
     D_IQ = np.zeros((n+1, n+1))
     D_IQ[range(n), range(n)] = σy
@@ -1710,7 +1710,7 @@ A_inv = np.linalg.inv(A)
 
 ```{code-cell} python3
 # compute the mean vectors of b and y
-μb = np.ones(T) * 𝛼0
+μb = np.full(T, 𝛼0)
 μb[0] += 𝛼1 * μy_tilde[1] + 𝛼2 * μy_tilde[0]
 μb[1] += 𝛼2 * μy_tilde[1]
 

--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -431,7 +431,7 @@ def param_plot():
     # Draw (t1, t2) points
     ρ1 = np.linspace(-2, 2, 100)
     ax.plot(ρ1, -abs(ρ1) + 1, c='black')
-    ax.plot(ρ1, np.ones_like(ρ1) * -1, c='black')
+    ax.plot(ρ1, np.full_like(ρ1, -1), c='black')
     ax.plot(ρ1, -(ρ1**2 / 4), c='black')
 
     # Turn normal axes off


### PR DESCRIPTION
Hi @jstac and @oyamad , thanks for your nice comments. This PR fix #165  's remaining patterns, mentioned by @oyamad , except for the following:
- [lake_model](https://python.quantecon.org/lake_model.html): ``V = np.ones(len(mcm.w_vec))``

Do you think we should also change the ``np.ones`` pattern to ``np.full`` in the above lecture?