### PR TITLE
FIX: Jax and M1 Compatibility

### DIFF
--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -16,7 +16,7 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install --upgrade jax jaxlib
+!conda install -y -c conda-forge jax jaxlib
 !conda install -y -c plotly plotly plotly-orca retrying
 ```
 
@@ -600,3 +600,4 @@ This lecture site is built in a server environment that doesn't have access to a
 If you run this lecture locally this lets you know where your code is being executed, either
 via the `cpu` or the `gpu`
 ```
+


### PR DESCRIPTION
A simple fix is to fetch `jax` from `conda-forge` which provides the `no arch` version of `jax` for `Apple Mac arm64 users`