### PR TITLE
[opt_transport] Update linprog_simplex import

### DIFF
--- a/lectures/opt_transport.md
+++ b/lectures/opt_transport.md
@@ -53,7 +53,7 @@ Let's start with some imports.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import linprog
-from quantecon.optimize import linprog_simplex
+from quantecon.optimize.linprog_simplex import linprog_simplex
 import ot
 from scipy.stats import binom, betabinom
 import networkx as nx


### PR DESCRIPTION
`opt_transport` was giving the following error on `cache` run:

```
[0;31mTypeError[0m: 'module' object is not callable
TypeError: 'module' object is not callable
```