### PR TITLE
ENH: Improve compatibility with Google Colab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/lectures/aiyagari.md
+++ b/lectures/aiyagari.md
@@ -30,7 +30,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -20,6 +20,13 @@ kernelspec:
 !conda install -y -c plotly plotly plotly-orca retrying
 ```
 
+```{note}
+If you are running this on Google Colab the above cell will 
+present an error. This is because Google Colab doesn't use Anaconda to manage
+the Python packages. However this lecture will still execute as Google Colab
+has `plotly` installed.
+```
+
 ## Overview
 
 Substantial parts of **machine learning** and **artificial intelligence** are about 

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/coleman_policy_iter.md
+++ b/lectures/coleman_policy_iter.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/egm_policy_iter.md
+++ b/lectures/egm_policy_iter.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -30,7 +30,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/harrison_kreps.md
+++ b/lectures/harrison_kreps.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture uses following libraries:
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install --upgrade yfinance
 ```
 

--- a/lectures/ifp.md
+++ b/lectures/ifp.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/kalman.md
+++ b/lectures/kalman.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -32,7 +32,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install --upgrade yfinance
 ```
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/linear_models.md
+++ b/lectures/linear_models.md
@@ -37,7 +37,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/lq_inventories.md
+++ b/lectures/lq_inventories.md
@@ -30,7 +30,7 @@ In addition to what's in Anaconda, this lecture employs the following library:
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -41,7 +41,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/markov_perf.md
+++ b/lectures/markov_perf.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/mccall_correlated.md
+++ b/lectures/mccall_correlated.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/mccall_fitted_vfi.md
+++ b/lectures/mccall_fitted_vfi.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/mccall_model.md
+++ b/lectures/mccall_model.md
@@ -38,7 +38,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/mccall_model_with_separation.md
+++ b/lectures/mccall_model_with_separation.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -30,8 +30,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!pip install quantecon
-!conda install -y -c conda-forge interpolation
+!pip install quantecon interpolation
 ```
 
 ```{code-cell} ipython

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -30,7 +30,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !conda install -y -c conda-forge interpolation
 ```
 

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -30,7 +30,7 @@ In addition to what’s in Anaconda, this lecture deploys the libraries:
 ---
 tags: [hide-output]
 ---
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 ```
 

--- a/lectures/optgrowth_fast.md
+++ b/lectures/optgrowth_fast.md
@@ -30,7 +30,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/perm_income_cons.md
+++ b/lectures/perm_income_cons.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/rational_expectations.md
+++ b/lectures/rational_expectations.md
@@ -34,7 +34,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -33,7 +33,7 @@ In addition to what's in Anaconda, this lecture deploys the following libraries:
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ```{code-cell} ipython

--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -36,7 +36,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!conda install -y quantecon
+!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -29,7 +29,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!conda install -y quantecon
+!pip install quantecon
 ```
 
 ## Overview


### PR DESCRIPTION
This PR improves compatibility with Google Colab by using `pip` as the package installer rather than `conda`. 

There are two incompatibilities that can't be resolved as the packages are not available via `pip`

- [ ] `back_prop.md` installs `plotly-orca`
- [ ] `navy_captain` install `interpolation` via conda-forge
