### PR TITLE
[geom_series] fix MatplotlibDeprecationWarning

### DIFF
--- a/lectures/geom_series.md
+++ b/lectures/geom_series.md
@@ -769,7 +769,7 @@ visualization!
 # Second view
 fig = plt.figure()
 T = 3
-ax = fig.gca(projection='3d')
+ax = plt.subplot(projection='3d')
 r = np.arange(0.01, 0.99, 0.005)
 g = np.arange(0.011, 0.991, 0.005)
 


### PR DESCRIPTION
Hi @jstac , this PR fixes the MatplotlibDeprecationWarning in lecture ``geom_series`` (left: before fixing; right: after fixing):
<img width="2447" alt="Screen Shot 2022-08-30 at 12 00 42 pm" src="https://user-images.githubusercontent.com/53931041/187331775-bf53a9d9-770a-496f-8bc4-3667ab76075f.png">
