### PR TITLE
Switch to Hint and Note Admonitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Build Project [using jupyter-book]
-on: [push]
+on: [pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Build Project [using jupyter-book]
-on: [pull_request]
+on: [push]
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/lectures/ar1_bayes.md
+++ b/lectures/ar1_bayes.md
@@ -275,8 +275,10 @@ Please note how the posterior for $\rho$ has shifted to the right relative to wh
 
 Think about why this happens.  
 
-**Hint:** It is connected to how Bayes Law (conditional probability) solves an **inverse problem** by putting high probability on parameter values
+```{hint}
+It is connected to how Bayes Law (conditional probability) solves an **inverse problem** by putting high probability on parameter values
 that make observations more likely.
+```
 
 We'll return to this issue after we use `numpyro` to compute posteriors under our two alternative assumptions about the distribution of $y_0$.
 

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -374,7 +374,10 @@ In particular, modulo randomness, reproduce the following figure (where the hori
 ```{figure} /_static/lecture_specific/career/career_solutions_ex1_py.png
 ```
 
-Hint: To generate the draws from the distributions $F$ and $G$, use `quantecon.random.draw()`.
+```{hint}
+:class: dropdown
+To generate the draws from the distributions $F$ and $G$, use `quantecon.random.draw()`.
+```
 
 ```{exercise-end}
 ```

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -177,9 +177,10 @@ consumer (also known as a *household*) chooses for itself subject to a budget co
 - The representative household and the representative firm are both
   **price takers** who believe that prices are not affected by their choices
 
-**Note:** We can think of there being  unit measures of identical representative consumers and 
+```{note}
+We can think of there being  unit measures of identical representative consumers and 
 identical representative firms.
-
+```
 ## Market Structure
 
 The representative household and the representative firm are both price takers.
@@ -627,9 +628,11 @@ within a competitive equilibrium.
 By {eq}`ge1` and {eq}`ge2` this allocation is
 identical to the one that solves the consumer's problem.
 
-**Note:** Because budget sets are affected only by relative prices,
+```{note}
+Because budget sets are affected only by relative prices,
 $\{q_0^t\}$ is determined only up to multiplication by a
 positive constant.
+```
 
 **Normalization:** We are free to choose a $\{q_0^t\}$ that
 makes $\lambda=1$ so that we are measuring $q_0^t$  in

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -181,6 +181,7 @@ consumer (also known as a *household*) chooses for itself subject to a budget co
 We can think of there being  unit measures of identical representative consumers and 
 identical representative firms.
 ```
+
 ## Market Structure
 
 The representative household and the representative firm are both price takers.

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -622,9 +622,9 @@ If you like you can use the function `qe.rank_size` from the `quantecon` library
 Use `np.random.seed(13)` to set the seed.
 ```
 
-```{exercise}
+```{exercise-start}
 :label: ht_ex5
-
+```
 There is an ongoing argument about whether the firm size distribution should
 be modeled as a Pareto distribution or a lognormal distribution (see, e.g.,
 {cite}`fujiwara2004pareto`, {cite}`kondo2018us` or {cite}`schluter2019size`).
@@ -669,9 +669,13 @@ For the seed use `np.random.seed(1234)`.
 
 What differences do you observe?
 
-(Note: a better approach to this problem would be to model firm dynamics and
+```{note}
+A better approach to this problem would be to model firm dynamics and
 try to track individual firms given the current distribution.  We will discuss
-firm dynamics in later lectures.)
+firm dynamics in later lectures.
+```
+
+```{exercise-end}
 ```
 
 ## Solutions

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -719,6 +719,7 @@ plt.show()
 
 ```{solution-start} ht_ex2
 :class: dropdown
+```
 
 Let $X$ have a Pareto tail with tail index $\alpha$ and let $F$ be its cdf.
 
@@ -742,8 +743,6 @@ $$
 We know that $\int_{\bar x}^\infty x^{r-\alpha-1} x = \infty$ whenever $r - \alpha - 1 \geq -1$.
 
 Since $r \geq \alpha$, we have $\mathbb E X^r = \infty$.
-```
-
 
 ```{solution-end}
 ```

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -625,6 +625,7 @@ Use `np.random.seed(13)` to set the seed.
 ```{exercise-start}
 :label: ht_ex5
 ```
+
 There is an ongoing argument about whether the firm size distribution should
 be modeled as a Pareto distribution or a lognormal distribution (see, e.g.,
 {cite}`fujiwara2004pareto`, {cite}`kondo2018us` or {cite}`schluter2019size`).

--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -124,7 +124,9 @@ In particular, if $y_1$ is log normal with parameters $(\mu_1, \sigma_1^2)$ and
 $y_2$ is log normal with parameters $(\mu_2, \sigma_2^2)$, then the product $y_1 y_2$ is log normal
 with parameters $(\mu_1 + \mu_2, \sigma_1^2 + \sigma_2^2)$.
 
-**Note:** While the product of two log normal distributions is log normal, the **sum** of two log normal distributions is **not** log normal.  
+```{note}
+While the product of two log normal distributions is log normal, the **sum** of two log normal distributions is **not** log normal.  
+```
 
 This observation sets the stage for challenge that confronts us in this lecture, namely, to approximate probability distributions of **sums** of independent log normal random variables.
 
@@ -577,9 +579,10 @@ mu6, sigma6 = 1.444, 1.4632
 mu7, sigma7 = -.040, 1.4632
 
 ```
-
-**Note:** Because the failure rates are all very small,  log normal distributions with the
+```{note}
+Because the failure rates are all very small,  log normal distributions with the
 above parameter values actually describe $P(A_i)$ times $10^{-09}$.
+```
 
 So the probabilities that we'll put on the $x$ axis of the probability mass function and associated cumulative distribution function should be multiplied by $10^{-09}$
 

--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -275,9 +275,10 @@ def pdf_seq(μ,σ,I,m):
 <!-- #region -->
 Now we shall set a grid length $I$ and a grid increment size $m =1$ for our discretizations.
 
-**Note**: We set $I$ equal to a power of two because we want to be free to use a Fast Fourier Transform
+```{note}
+We set $I$ equal to a power of two because we want to be free to use a Fast Fourier Transform
 to compute a convolution of two sequences (discrete distributions).
-
+```
 
 We recommend experimenting with different values of the power $p$ of 2.
 
@@ -302,7 +303,7 @@ NT = x.size
 
 plt.figure(figsize = (8,8))
 plt.subplot(2,1,1)
-plt.plot(x[:np.int(NT)],p1[:np.int(NT)],label = '')
+plt.plot(x[:int(NT)],p1[:int(NT)],label = '')
 plt.xlim(0,2500)
 count, bins, ignored = plt.hist(s1, 1000, density=True, align='mid')
 

--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -416,7 +416,7 @@ NT= np.size(x)
 
 plt.figure(figsize = (8,8))
 plt.subplot(2,1,1)
-plt.plot(x[:np.int(NT)],c1f[:np.int(NT)]/m,label = '')
+plt.plot(x[:int(NT)],c1f[:int(NT)]/m,label = '')
 plt.xlim(0,5000)
 
 count, bins, ignored = plt.hist(ssum2, 1000, density=True, align='mid')
@@ -429,7 +429,7 @@ plt.show()
 NT= np.size(x)
 plt.figure(figsize = (8,8))
 plt.subplot(2,1,1)
-plt.plot(x[:np.int(NT)],c2f[:np.int(NT)]/m,label = '')
+plt.plot(x[:int(NT)],c2f[:int(NT)]/m,label = '')
 plt.xlim(0,5000)
 
 count, bins, ignored = plt.hist(ssum3, 1000, density=True, align='mid')
@@ -654,9 +654,9 @@ print("time for 13 convolutions = ", tdiff13)
 
 ```{code-cell} python3
 d13 = np.cumsum(c13)
-Nx=np.int(1400)
+Nx=int(1400)
 plt.figure()
-plt.plot(x[0:np.int(Nx/m)],d13[0:np.int(Nx/m)])  # show Yad this -- I multiplied by m -- step size
+plt.plot(x[0:int(Nx/m)],d13[0:int(Nx/m)])  # show Yad this -- I multiplied by m -- step size
 plt.hlines(0.5,min(x),Nx,linestyles='dotted',colors = {'black'})
 plt.hlines(0.9,min(x),Nx,linestyles='dotted',colors = {'black'})
 plt.hlines(0.95,min(x),Nx,linestyles='dotted',colors = {'black'})

--- a/lectures/house_auction.md
+++ b/lectures/house_auction.md
@@ -43,9 +43,10 @@ We describe two distinct mechanisms
  
  * A special case of a Groves-Clarke {cite}`Groves_73`, {cite}`Clarke_71` mechanism with a benevolent social planner
 
+```{note}
+In 1994, the multiple rounds, ascending bid auction was actually used by Stanford University to sell leases to 9 lots on the Stanford campus to eligible faculty members.
+```
 
-**Note:** In 1994, the multiple rounds, ascending bid auction was actually used by Stanford University to sell leases to 9 lots on the Stanford campus to eligible faculty members.
- 
 We begin with  overviews of the two mechanisms.
 
 ## Ascending Bids Auction for Multiple Goods

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -922,8 +922,9 @@ In this exercise, your task is to arrange the `LakeModel` class by using descrip
 ```
 
 
-```{exercise}
+```{exercise-start}
 :label: lm_ex2
+```
 
 Consider an economy with an initial stock  of workers $N_0 = 100$ at the
 steady state level of employment in the baseline parameterization
@@ -945,7 +946,11 @@ How long does the economy take to converge to its new steady state?
 
 What is the new steady state level of employment?
 
-Note: it may be easier to use the class created in exercise 1 to help with changing variables.
+```{note}
+It may be easier to use the class created in exercise 1 to help with changing variables.
+```
+
+```{exercise-end}
 ```
 
 

--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -771,10 +771,12 @@ where
 * each $U_i$ is an IID draw from the uniform distribution on $[-2, 2]$.
 * $U_i$ and $W_i$ are independent of each other.
 
-Hints:
+```{hint}
+:class: dropdown
 
 1. `scipy.linalg.sqrtm(A)` computes the square root of `A`.  You still need to invert it.
 1. You should be able to work out $\Sigma$ from the preceding information.
+```
 
 ```{exercise-end}
 ```

--- a/lectures/mccall_model_with_separation.md
+++ b/lectures/mccall_model_with_separation.md
@@ -124,7 +124,9 @@ If he rejects, then he receives unemployment compensation $c$.
 
 The process then repeats.
 
-(Note: we do not allow for job search while employed---this topic is taken up in a {doc}`later lecture <jv>`.)
+```{note}
+We do not allow for job search while employed---this topic is taken up in a {doc}`later lecture <jv>`.
+```
 
 ## Solving the Model
 

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -520,6 +520,7 @@ Write a program that quickly returns all values in the `MultiIndex`.
 ```{exercise-start}
 :label: pp_ex2
 ```
+
 Filter the above dataframe to only include employment as a percentage of
 'active population'.
 
@@ -528,6 +529,7 @@ by age group and sex.
 
 ```{hint}
 :class: dropdown
+
 `GEO` includes both areas and countries.
 ```
 

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -517,16 +517,21 @@ Write a program that quickly returns all values in the `MultiIndex`.
 ```
 
 
-```{exercise}
+```{exercise-start}
 :label: pp_ex2
-
+```
 Filter the above dataframe to only include employment as a percentage of
 'active population'.
 
 Create a grouped boxplot using `seaborn` of employment rates in 2015
 by age group and sex.
 
-**Hint:** `GEO` includes both areas and countries.
+```{hint}
+:class: dropdown
+`GEO` includes both areas and countries.
+```
+
+```{exercise-end}
 ```
 
 ## Solutions

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -153,7 +153,7 @@ Selecting one year and stacking the two lower levels of the
 `MultiIndex` creates a cross-section of our panel data
 
 ```{code-cell} python3
-realwage['2015'].stack(level=(1, 2)).transpose().head()
+realwage.loc['2015'].stack(level=(1, 2)).transpose().head()
 ```
 
 For the rest of lecture, we will work with a dataframe of the hourly
@@ -398,13 +398,13 @@ We can also specify a level of the `MultiIndex` (in the column axis)
 to aggregate over
 
 ```{code-cell} python3
-merged.mean(level='Continent', axis=1).head()
+merged.groupby(level='Continent', axis=1).mean().head()
 ```
 
 We can plot the average minimum wages in each continent as a time series
 
 ```{code-cell} python3
-merged.mean(level='Continent', axis=1).plot()
+merged.groupby(level='Continent', axis=1).mean().plot()
 plt.title('Average real minimum wage')
 plt.ylabel('2015 USD')
 plt.xlabel('Year')
@@ -415,7 +415,7 @@ We will drop Australia as a continent for plotting purposes
 
 ```{code-cell} python3
 merged = merged.drop('Australia', level='Continent', axis=1)
-merged.mean(level='Continent', axis=1).plot()
+merged.groupby(level='Continent', axis=1).mean().plot()
 plt.title('Average real minimum wage')
 plt.ylabel('2015 USD')
 plt.xlabel('Year')
@@ -473,7 +473,7 @@ import seaborn as sns
 continents = grouped.groups.keys()
 
 for continent in continents:
-    sns.kdeplot(grouped.get_group(continent)['2015'].unstack(), label=continent, shade=True)
+    sns.kdeplot(grouped.get_group(continent).loc['2015'].unstack(), label=continent, shade=True)
 
 plt.title('Real minimum wages in 2015')
 plt.xlabel('US dollars')
@@ -608,7 +608,7 @@ employ_f = employ_f.drop('Total', level='SEX', axis=1)
 ```
 
 ```{code-cell} python3
-box = employ_f['2015'].unstack().reset_index()
+box = employ_f.loc['2015'].unstack().reset_index()
 sns.boxplot(x="AGE", y=0, hue="SEX", data=box, palette=("husl"), showfliers=False)
 plt.xlabel('')
 plt.xticks(rotation=35)

--- a/lectures/prob_matrix.md
+++ b/lectures/prob_matrix.md
@@ -473,7 +473,9 @@ We can draw a sample of a random variable $X$ with a known CDF as follows:
 
 Thus, knowing the **"inverse"** CDF of a distribution is enough to simulate from this distribution.
 
-**NOTE**: The "inverse" CDF needs to exist for this method to work.
+```{note}
+The "inverse" CDF needs to exist for this method to work.
+```
 
 The inverse CDF is 
 

--- a/lectures/prob_matrix.md
+++ b/lectures/prob_matrix.md
@@ -624,8 +624,9 @@ Thus $x$ is the smallest integer such that the discrete geometric CDF is greater
 
 We can verify that $x$ is indeed geometrically distributed by the following `numpy` program.
 
-**Note:** The exponential distribution is the continuous analog of geometric distribution.
-
+```{note}
+The exponential distribution is the continuous analog of geometric distribution.
+```
 
 ```{code-cell} ipython3
 n, λ = 1_000_000, 0.8

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -345,11 +345,12 @@ where
 
 F = (1-\lambda) G (I - \lambda A)^{-1}
 ```
-
-**Note:** As mentioned above, an *explosive solution* of difference
+```{note}
+As mentioned above, an *explosive solution* of difference
 equation {eq}`equation_1` can be constructed by adding to the right hand of {eq}`equation_4` a
 sequence $c \lambda^{-t}$ where $c$ is an arbitrary positive
 constant.
+```
 
 ## Some Python Code
 

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -345,6 +345,7 @@ where
 
 F = (1-\lambda) G (I - \lambda A)^{-1}
 ```
+
 ```{note}
 As mentioned above, an *explosive solution* of difference
 equation {eq}`equation_1` can be constructed by adding to the right hand of {eq}`equation_4` a

--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -271,8 +271,10 @@ Other lines have a similar interpretation.
 
 Your task is to use the algorithm given above to find the optimal path and its cost.
 
-Note: You will be dealing with floating point numbers now, rather than
+```{note}
+You will be dealing with floating point numbers now, rather than
 integers, so consider replacing `np.equal()` with `np.allclose()`.
+```
 
 ```{code-cell} python3
 %%file graph.txt


### PR DESCRIPTION
Hi @mmcky,

This resolves #266. I also fixed a few deprecations and bugs along the way:
1.  In [hoist_failure.md](https://python.quantecon.org/hoist_failure.html#fault-tree-uncertainties), there are a few deprecation warnings for `np.int()`, which is replaced by `int()`.
2. In [pandas_panel.md](https://python.quantecon.org/pandas_panel.html), `realwage['2015']` raises future warning and changed to `realwage.loc['2015']`, and similarly, `merged.mean(level='Continent', axis=1).head()` is changed to `merged.groupby(level='Continent', axis=1).mean()`
3. [Exercise 2 of Heavy-Tailed Distributions](https://python.quantecon.org/heavy_tails.html#solutions) was not shown and is now fixed.


Could you please review these changes, and merge them if it looks good to you?

Many thanks.