### PR TITLE
Enable LaTeX availability during cache runs

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -47,6 +47,21 @@ jobs:
         run: |
           pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
+      # Install LaTeX (Support for matplotlib)
+      - name: Install latex dependencies
+        shell: bash -l {0}
+        run: |
+          apt-get -qq update
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get install -y tzdata
+          apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy
       - name: Build HTML
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
This PR enables `latex` access during `cache.yml` runs to ensure matplotlib has access to `latex` for rendering latex strings as a subprocess