### PR TITLE
Fix small errors and add one tag

### DIFF
--- a/lectures/newton_method.md
+++ b/lectures/newton_method.md
@@ -470,7 +470,7 @@ Let's start by computing the market equilibrium of a two-good problem.
 We consider a market for two related products, good 0 and good 1, with
 price vector $p = (p_0, p_1)$
 
-Supply of good $i$ at price $p$,
+Supply of good $i$ at price $p$ is,
 
 $$ 
 q^s_i (p) = b_i \sqrt{p_i} 
@@ -549,13 +549,13 @@ A = \begin{pmatrix}
         \end{pmatrix},
             \qquad 
     b = \begin{pmatrix}
-            0 \\
-            0
+            1 \\
+            1
         \end{pmatrix}
     \qquad \text{and} \qquad
     c = \begin{pmatrix}
-            0 \\
-            0
+            1 \\
+            1
         \end{pmatrix}
 $$
 

--- a/lectures/newton_method.md
+++ b/lectures/newton_method.md
@@ -91,6 +91,7 @@ model](https://en.wikipedia.org/wiki/Solow%E2%80%93Swan_model).
 We will inspect the fixed point visually, solve it by successive
 approximation, and then apply Newton's method to achieve faster convergence.
 
+
 (solow)=
 ### The Solow Model
 
@@ -462,7 +463,7 @@ performance of the two methods again.
 
 We will see a significant performance gain when using Netwon's method.
 
-
+(two_goods_market)=
 ### A Two Goods Market Equilibrium
 
 Let's start by computing the market equilibrium of a two-good problem.


### PR DESCRIPTION
This PR 

- Fixes the wrong visualization of matrix b and c
https://github.com/QuantEcon/lecture-python.myst/blob/604d707e132261bc9071bc5f9faf9e1c4e35f670/lectures/newton_method.md?plain=1#L545-L570

- Adds a tag before 
https://github.com/QuantEcon/lecture-python.myst/blob/604d707e132261bc9071bc5f9faf9e1c4e35f670/lectures/newton_method.md?plain=1#L466

  to link the new Jax version of Newton's Method back to the same topic.

Also, @jstac I'm confused with the interpretation of the excess demand function in python.
In line 482, exp( - A @ p) is used to represent the $e^{-a_{i0} p_0} + e^{-a_{i1} p_1}, i = 0, 1$ part in the excess demand function but I think they are not mathematically equivalent.

