### PR TITLE
[LakeModel] Simplify computation of the steady state

### DIFF
--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -218,7 +218,7 @@ This class will
 1. store the primitives $\alpha, \lambda, b, d$
 1. compute and store the implied objects $g, A, \hat A$
 1. provide methods to simulate dynamics of the stocks and rates
-2. provide a method to compute the steady state vector of employment and unemployment rates $\bar x$ using {ref}`a technique <dynamics_workers>` we previously introduced for computing stationary distributions of Markov chains
+2. provide a method to compute the steady state vector $\bar x$ of employment and unemployment rates using {ref}`a technique <dynamics_workers>` we previously introduced for computing stationary distributions of Markov chains
 
 Please be careful because the implied objects $g, A, \hat A$ will not change
 if you only change the primitives.

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -218,7 +218,7 @@ This class will
 1. store the primitives $\alpha, \lambda, b, d$
 1. compute and store the implied objects $g, A, \hat A$
 1. provide methods to simulate dynamics of the stocks and rates
-1. provide a method to compute the steady state of the rate (We will discuss it in section {ref}`dynamics_workers`)
+1. provide a method to compute the steady state of the rate (which we discuss in section {ref}`dynamics_workers`)
 
 Please be careful because the implied objects $g, A, \hat A$ will not change
 if you only change the primitives.

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -265,7 +265,7 @@ class LakeModel:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = np.array([self.A_hat[0, 1], self.A_hat[1, 0]])
+        x = np.array([self.A_hat[1, 0], self.A_hat[0, 1]])
         x /= x.sum()
         return x
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -1013,7 +1013,7 @@ class LakeModelModified:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = np.array([self.A_hat[0, 1], self.A_hat[1, 0]])
+        x = np.array([self.A_hat[1, 0], self.A_hat[0, 1]])
         x /= x.sum()
         return x
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -265,7 +265,7 @@ class LakeModel:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = np.array([self.A_hat[1, 0], self.A_hat[0, 1]])
+        x = np.array([self.A_hat[0, 1], self.A_hat[1, 0]])
         x /= x.sum()
         return x
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -218,7 +218,7 @@ This class will
 1. store the primitives $\alpha, \lambda, b, d$
 1. compute and store the implied objects $g, A, \hat A$
 1. provide methods to simulate dynamics of the stocks and rates
-2. provide a method to compute the steady state rate using {ref}`a technique <dynamics_workers>` we previously introduced for computing stationary distributions of Markov chains
+2. provide a method to compute the steady state vector of employment and unemployment rates $\bar x$ using {ref}`a technique <dynamics_workers>` we previously introduced for computing stationary distributions of Markov chains
 
 Please be careful because the implied objects $g, A, \hat A$ will not change
 if you only change the primitives.

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -218,7 +218,7 @@ This class will
 1. store the primitives $\alpha, \lambda, b, d$
 1. compute and store the implied objects $g, A, \hat A$
 1. provide methods to simulate dynamics of the stocks and rates
-1. provide a method to compute the steady state of the rate (discussed in {ref}`dynamics_workers`)
+1. provide a method to compute the steady state of the rate (We will discuss it in section {ref}`dynamics_workers`)
 
 Please be careful because the implied objects $g, A, \hat A$ will not change
 if you only change the primitives.

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -1013,7 +1013,7 @@ class LakeModelModified:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = np.array([self.A_hat[1, 0], self.A_hat[0, 1]])
+        x = np.array([self.A_hat[0, 1], self.A_hat[1, 0]])
         x /= x.sum()
         return x
 

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -265,12 +265,8 @@ class LakeModel:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = np.full(2, 0.5)
-        error = tol + 1
-        while error > tol:
-            new_x = self.A_hat @ x
-            error = np.max(np.abs(new_x - x))
-            x = new_x
+        x = np.array([self.A_hat[0, 1], self.A_hat[1, 0]])
+        x /= x.sum()
         return x
 
     def simulate_stock_path(self, X0, T):

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -218,7 +218,7 @@ This class will
 1. store the primitives $\alpha, \lambda, b, d$
 1. compute and store the implied objects $g, A, \hat A$
 1. provide methods to simulate dynamics of the stocks and rates
-1. provide a method to compute the steady state of the rate
+1. provide a method to compute the steady state of the rate (discussed in {ref}`dynamics_workers`)
 
 Please be careful because the implied objects $g, A, \hat A$ will not change
 if you only change the primitives.
@@ -411,6 +411,7 @@ plt.tight_layout()
 plt.show()
 ```
 
+(dynamics_workers)=
 ## Dynamics of an Individual Worker
 
 An individual worker's employment dynamics are governed by a {doc}`finite state Markov process <finite_markov>`.
@@ -1012,12 +1013,8 @@ class LakeModelModified:
         --------
         xbar : steady state vector of employment and unemployment rates
         """
-        x = np.full(2, 0.5)
-        error = tol + 1
-        while error > tol:
-            new_x = self.A_hat @ x
-            error = np.max(np.abs(new_x - x))
-            x = new_x
+        x = np.array([self.A_hat[0, 1], self.A_hat[1, 0]])
+        x /= x.sum()
         return x
 
     def simulate_stock_path(self, X0, T):

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -218,7 +218,7 @@ This class will
 1. store the primitives $\alpha, \lambda, b, d$
 1. compute and store the implied objects $g, A, \hat A$
 1. provide methods to simulate dynamics of the stocks and rates
-1. provide a method to compute the steady state of the rate (which we discuss in section {ref}`dynamics_workers`)
+2. provide a method to compute the steady state rate using {ref}`a technique <dynamics_workers>` we previously introduced for computing stationary distributions of Markov chains
 
 Please be careful because the implied objects $g, A, \hat A$ will not change
 if you only change the primitives.


### PR DESCRIPTION
Compute the steady state by the straightforward formula for a 2x2 Markov chain instead of iteration.
See also: #169.