### PR TITLE
MAINT: switch backend to github actions rather than EC2

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -4,39 +4,20 @@ on:
     branches:
       - main
 jobs:
-  deploy-runner:
+  cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: iterative/setup-cml@v1
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Anaconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
-  cache:
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
-    container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
-      options: --gpus all
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Check nvidia drivers
-        shell: bash -l {0}
-        run: |
-          nvidia-smi
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: quantecon
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,33 @@
 name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
-  deploy-runner:
+  preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: iterative/setup-cml@v1
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Anaconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: quantecon        
+      - name: Install latex dependencies
         run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
-  preview:
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
-    container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
-      options: --gpus all
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      # Check nvidia drivers
-      - name: nvidia Drivers
-        shell: bash -l {0}
-        run: nvidia-smi
+          sudo apt-get -qq update
+          sudo apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy                     \
+            dvipng                    \
+            cm-super          
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,42 +4,34 @@ on:
     tags:
       - 'publish*'
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v1
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
-    container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
-      options: --gpus all
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Git (required to commit notebooks)
-        shell: bash -l {0}
-        run: apt-get install -y git
-      - name: Check nvidia drivers
-        shell: bash -l {0}
+      - name: Setup Anaconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: quantecon
+      - name: Install latex dependencies
         run: |
-          nvidia-smi
+          sudo apt-get -qq update
+          sudo apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy                     \
+            dvipng                    \
+            cm-super
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -18,6 +18,4 @@ This table contains the latest execution statistics.
 
 (status:machine-details)=
 
-These lectures are built on `linux` instances through `github actions`  and `amazon web services (aws)` to
-enable access to a `gpu`. These lectures are built on a [p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/)
-that has access to `8 vcpu's`, a `V100 NVIDIA Tesla GPU`, and `61 Gb` of memory.
+These lectures are built on `linux` instances through `github actions` on `ubuntu-latest`


### PR DESCRIPTION
This PR migrates from `EC2` powered backend to `GitHub Actions` as `jax` and `gpu` are no longer required. 

Fixes #359 

Review the following lectures for `jax` dependencies

- [ ] ar1_bayes
- [ ] back_prop
- [ ] bayes_nonconj
- [ ] mix_model

**Checks:**

- [ ] remove the cache and check a full build executes properly before merge