### PR TITLE
MAINT: Fix small typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/lectures/aiyagari.md
+++ b/lectures/aiyagari.md
@@ -55,7 +55,6 @@ The Aiyagari model has been used to investigate many topics, including
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/ar1_bayes.md
+++ b/lectures/ar1_bayes.md
@@ -34,8 +34,6 @@ import jax.numpy as jnp
 from jax import random
 import matplotlib.pyplot as plt
 
-%matplotlib inline
-
 import logging
 logging.basicConfig()
 logger = logging.getLogger('pymc')
@@ -71,7 +69,7 @@ $$ (eq:themodel_2)
 
 
 
-Consider a sample $\{y_t\}_{t=0}^T$ governed by this statistical model.  
+Consider a sample $\{y_t\}_{t=0}^T$ governed by this statistical model.
 
 The model
 implies that the likelihood function of $\{y_t\}_{t=0}^T$ can be **factored**:
@@ -80,7 +78,7 @@ $$
 f(y_T, y_{T-1}, \ldots, y_0) = f(y_T| y_{T-1}) f(y_{T-1}| y_{T-2}) \cdots f(y_1 | y_0 ) f(y_0)
 $$
 
-where we use $f$ to denote a generic probability density.  
+where we use $f$ to denote a generic probability density.
 
 The  statistical model {eq}`eq:themodel`-{eq}`eq:themodel_2` implies
 
@@ -95,7 +93,7 @@ We want to study how inferences about the unknown parameters $(\rho, \sigma_x)$ 
 
 Below, we study two widely used alternative assumptions:
 
--  $(\mu_0,\sigma_0) = (y_0, 0)$ which means  that $y_0$ is  drawn from the distribution ${\mathcal N}(y_0, 0)$; in effect, we are **conditioning on an observed initial value**.  
+-  $(\mu_0,\sigma_0) = (y_0, 0)$ which means  that $y_0$ is  drawn from the distribution ${\mathcal N}(y_0, 0)$; in effect, we are **conditioning on an observed initial value**.
 
 -  $\mu_0,\sigma_0$ are functions of $\rho, \sigma_x$ because $y_0$ is drawn from the stationary distribution implied by $\rho, \sigma_x$.
 
@@ -105,7 +103,7 @@ Below, we study two widely used alternative assumptions:
 
 Unknown parameters are $\rho, \sigma_x$.
 
-We have  independent **prior probability distributions** for $\rho, \sigma_x$ and want to compute a posterior probability distribution after observing a sample $\{y_{t}\}_{t=0}^T$.  
+We have  independent **prior probability distributions** for $\rho, \sigma_x$ and want to compute a posterior probability distribution after observing a sample $\{y_{t}\}_{t=0}^T$.
 
 The notebook uses `pymc4` and `numpyro` to compute a posterior distribution of $\rho, \sigma_x$. We will use NUTS samplers to generate samples from the posterior in a chain. Both of these libraries support NUTS samplers.
 
@@ -113,12 +111,12 @@ NUTS is a form of Monte Carlo Markov Chain (MCMC) algorithm that bypasses random
 
 Thus, we explore consequences of making these alternative assumptions about the distribution of $y_0$:
 
-- A first procedure is to condition on whatever value of $y_0$ is observed. This amounts to assuming that the probability distribution of the random variable  $y_0$ is a Dirac delta function that puts probability one on the observed value of $y_0$.    
+- A first procedure is to condition on whatever value of $y_0$ is observed. This amounts to assuming that the probability distribution of the random variable  $y_0$ is a Dirac delta function that puts probability one on the observed value of $y_0$.
 
 - A second procedure  assumes that $y_0$ is drawn from the stationary distribution of a process described by {eq}`eq:themodel`
 so that  $y_0 \sim {\cal N} \left(0, {\sigma_x^2\over (1-\rho)^2} \right) $
 
-When the initial value $y_0$ is far out in a tail of the stationary distribution, conditioning on an initial value gives a posterior that is **more accurate** in a sense that we'll explain.   
+When the initial value $y_0$ is far out in a tail of the stationary distribution, conditioning on an initial value gives a posterior that is **more accurate** in a sense that we'll explain.
 
 Basically, when $y_0$ happens to be  in a tail of the stationary distribution and we **don't condition on $y_0$**, the likelihood function for $\{y_t\}_{t=0}^T$ adjusts the posterior distribution of the parameter pair $\rho, \sigma_x $ to make the observed value of $y_0$  more likely than it really is under the stationary distribution, thereby adversely twisting the posterior in short samples.
 
@@ -129,7 +127,7 @@ We begin by solving a **direct problem** that simulates an AR(1) process.
 
 How we select the initial value $y_0$ matters.
 
-   * If we think $y_0$ is drawn from the stationary distribution ${\mathcal N}(0, \frac{\sigma_x^{2}}{1-\rho^2})$, then it is a good idea to use this distribution as $f(y_0)$.  Why? Because $y_0$ contains information about $\rho, \sigma_x$.  
+   * If we think $y_0$ is drawn from the stationary distribution ${\mathcal N}(0, \frac{\sigma_x^{2}}{1-\rho^2})$, then it is a good idea to use this distribution as $f(y_0)$.  Why? Because $y_0$ contains information about $\rho, \sigma_x$.
 
    * If we suspect that $y_0$ is far in the tails of the stationary distribution -- so that variation in early observations in the sample have a significant **transient component** -- it is better to condition on $y_0$ by setting $f(y_0) = 1$.
 
@@ -273,7 +271,7 @@ summary_y0
 
 Please note how the posterior for $\rho$ has shifted to the right relative to when we conditioned on $y_0$ instead of assuming that $y_0$ is drawn from the stationary distribution.
 
-Think about why this happens.  
+Think about why this happens.
 
 ```{hint}
 It is connected to how Bayes Law (conditional probability) solves an **inverse problem** by putting high probability on parameter values

--- a/lectures/ar1_processes.md
+++ b/lectures/ar1_processes.md
@@ -47,7 +47,6 @@ Let's start with some imports:
 
 ```{code-cell} ipython
 import numpy as np
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 ```

--- a/lectures/cake_eating_numerical.md
+++ b/lectures/cake_eating_numerical.md
@@ -46,7 +46,6 @@ accuracy of alternative numerical methods.
 We will use the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/cake_eating_problem.md
+++ b/lectures/cake_eating_problem.md
@@ -40,7 +40,6 @@ Readers might find it helpful to review the following lectures before reading th
 In what follows, we require the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -47,7 +47,6 @@ This exposition draws on the presentation in {cite}`Ljungqvist2012`, section 6.5
 We begin with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/cass_koopmans_1.md
+++ b/lectures/cass_koopmans_1.md
@@ -65,7 +65,6 @@ The lecture uses important ideas including
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, float64
@@ -101,9 +100,9 @@ There is a unit mass of identical consumers.
 
 For $\omega \in [0,1]$, consumption of consumer  is $c(\omega)$.
 
-Aggregate consumption is 
+Aggregate consumption is
 
-$$ 
+$$
 C = \int_0^1 c(\omega) d \omega
 $$
 
@@ -111,36 +110,36 @@ Consider the a welfare problem of choosing an allocation $\{c(\omega)\}$ across 
 
 $$
  \int_0^1 u(c(\omega)) d \omega
-$$ 
+$$
 
-where $u(\cdot)$ is a concave utility function with $u' >0, u'' < 0$ and  maximization is subject to 
+where $u(\cdot)$ is a concave utility function with $u' >0, u'' < 0$ and  maximization is subject to
 
-$$ 
+$$
 C = \int_0^1 c(\omega) d \omega .
 $$ (eq:feas200)
 
 Form a Lagrangian $L = \int_0^1 u(c(\omega)) d \omega + \lambda [C - \int_0^1 c(\omega) d \omega ] $.
 
 Differentiate under the integral signs with respect to each $\omega$ to  obtain the first-order
-necessary condtions 
+necessary condtions
 
 $$
-u'(c(\omega)) = \lambda. 
-$$ 
+u'(c(\omega)) = \lambda.
+$$
 
-This condition implies that $c(\omega)$ equals a constant $c$ that is independent 
-of $\omega$.  
+This condition implies that $c(\omega)$ equals a constant $c$ that is independent
+of $\omega$.
 
-To find $c$, use the  feasibility constraint {eq}`eq:feas200` to conclude that 
+To find $c$, use the  feasibility constraint {eq}`eq:feas200` to conclude that
 
-$$ 
+$$
 c(\omega) = c = C.
 $$
 
-This line of argument indicates the special *aggregation theory* that lies beneath outcomes in which a representative consumer 
+This line of argument indicates the special *aggregation theory* that lies beneath outcomes in which a representative consumer
 consumes amount $C$.
 
-It appears often in aggregate economics. 
+It appears often in aggregate economics.
 
 We shall use it in this lecture and in {doc}`Cass-Koopmans Competitive Equilibrium <cass_koopmans_2>`.
 
@@ -900,4 +899,3 @@ by a representative household and a representative firm.
 
 The relationship between a command economy like the one studied in this lecture and a market economy like that
 studied in {doc}`Cass-Koopmans Competitive Equilibrium <cass_koopmans_2>` is a foundational topic in general equilibrium theory and welfare economics.
-

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -45,7 +45,7 @@ The earlier  lecture {doc}`Cass-Koopmans Planning Model <cass_koopmans_1>` studi
 The present lecture uses  additional  ideas including
 
 - Hicks-Arrow prices, named after John R. Hicks and Kenneth Arrow.
-- A connection between some Lagrange multipliers from the planning 
+- A connection between some Lagrange multipliers from the planning
   problem and the Hicks-Arrow prices.
 - A **Big** $K$ **, little** $k$ trick widely used in
   macroeconomic dynamics.
@@ -66,7 +66,6 @@ The present lecture uses  additional  ideas including
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, float64
@@ -178,7 +177,7 @@ consumer (also known as a *household*) chooses for itself subject to a budget co
   **price takers** who believe that prices are not affected by their choices
 
 ```{note}
-We can think of there being  unit measures of identical representative consumers and 
+We can think of there being  unit measures of identical representative consumers and
 identical representative firms.
 ```
 
@@ -198,13 +197,13 @@ all other dates $t=1, 2, \ldots, T$.
 
 There are  sequences of prices
 $\{w_t,\eta_t\}_{t=0}^T= \{\vec{w}, \vec{\eta} \}$
-where 
+where
 
 - $w_t$ is a wage or rental rate for labor at time $t$
 
 - $\eta_t$ is a rental rate for capital at time $t$
 
-In addition there is a vector $\{q_t^0\}$ of  intertemporal prices where  
+In addition there is a vector $\{q_t^0\}$ of  intertemporal prices where
 
 - $q^0_t$ is the price of a good at date $t$ relative
 to a good at date $0$.
@@ -212,7 +211,7 @@ to a good at date $0$.
 We call $\{q^0_t\}_{t=0}^T$  a vector of **Hicks-Arrow prices**,
 named after the 1972 economics Nobel prize winners.
 
-Units of $q_t^0$ could be 
+Units of $q_t^0$ could be
 
 $$
 \frac{\text{number of time 0 goods}}{\text{number of time t goods}}
@@ -970,4 +969,3 @@ Now we plot when $t_0=20$
 ```{code-cell} python3
 plot_yield_curves(pp, 20, 0.3, k_ss/3, T_arr)
 ```
-

--- a/lectures/coleman_policy_iter.md
+++ b/lectures/coleman_policy_iter.md
@@ -61,7 +61,6 @@ iteration can be further adjusted to obtain even more efficiency.
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -98,7 +98,6 @@ $$
 We'll need the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/egm_policy_iter.md
+++ b/lectures/egm_policy_iter.md
@@ -50,7 +50,6 @@ The original reference is {cite}`Carroll2006`.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/eig_circulant.md
+++ b/lectures/eig_circulant.md
@@ -33,7 +33,6 @@ We begin by importing some Python packages
 import numpy as np
 from numba import njit
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ```{code-cell} ipython3
@@ -42,7 +41,7 @@ np.set_printoptions(precision=3, suppress=True)
 
 ## Constructing a Circulant Matrix
 
-To construct an $N \times N$ circulant matrix, we  need only the first row, say,  
+To construct an $N \times N$ circulant matrix, we  need only the first row, say,
 
 $$ \begin{bmatrix} c_{0} & c_{1} & c_{2} & c_{3} & c_{4} & \cdots & c_{N-1} \end{bmatrix} .$$
 
@@ -71,7 +70,7 @@ Let's write some Python code to generate a circulant matrix.
 def construct_cirlulant(row):
 
     N = row.size
-    
+
     C = np.empty((N, N))
 
     for i in range(N):
@@ -96,23 +95,23 @@ Suppose that $A$ and $B$ are both circulant matrices. Then it can be verified th
  * The transpose of a circulant matrix is a circulant matrix.
 
 
- 
+
   * $A + B$ is a circulant matrix
   * $A B$ is a circulant matrix
-  * $A B = B A$ 
+  * $A B = B A$
 
-Now consider a circulant matrix with first row 
+Now consider a circulant matrix with first row
 
   $$  c = \begin{bmatrix} c_0 & c_1 & \cdots & c_{N-1} \end{bmatrix} $$
 
- and consider a vector 
+ and consider a vector
 
  $$ a = \begin{bmatrix} a_0 & a_1 & \cdots  &  a_{N-1} \end{bmatrix} $$
 
  The **convolution** of  vectors $c$ and $a$ is defined   as the vector $b = c * a $  with components
 
 $$
- b_k = \sum_{i=0}^{n-1} c_{k-i} a_i  
+ b_k = \sum_{i=0}^{n-1} c_{k-i} a_i
 $$ (eqn:conv)
 
 We use $*$ to denote **convolution** via the calculation described in equation {eq}`eqn:conv`.
@@ -121,7 +120,7 @@ It can be verified that the vector $b$ satisfies
 
 $$ b = C^T a  $$
 
-where $C^T$ is the transpose of the circulant matrix  defined in equation {eq}`eqn:circulant`.  
+where $C^T$ is the transpose of the circulant matrix  defined in equation {eq}`eqn:circulant`.
 
 
 
@@ -135,10 +134,10 @@ Before defining a permutation **matrix**, we'll define a **permutation**.
 
 A **permutation** of a set of the set of non-negative integers $\{0, 1, 2, \ldots \}$ is a one-to-one mapping of the set into itself.
 
-A permutation of a set $\{1, 2, \ldots, n\}$ rearranges the $n$ integers in the set.  
+A permutation of a set $\{1, 2, \ldots, n\}$ rearranges the $n$ integers in the set.
 
 
-A [permutation matrix](https://mathworld.wolfram.com/PermutationMatrix.html) is obtained by permuting the rows of an $n \times n$ identity matrix according to a permutation of the numbers $1$ to $n$. 
+A [permutation matrix](https://mathworld.wolfram.com/PermutationMatrix.html) is obtained by permuting the rows of an $n \times n$ identity matrix according to a permutation of the numbers $1$ to $n$.
 
 
 Thus, every row and every column contain precisely a single $1$ with $0$ everywhere else.
@@ -158,7 +157,7 @@ P=\left[\begin{array}{cccccc}
 \end{array}\right]
 $$ (eqn:exampleP)
 
-serves as  a **cyclic shift**  operator that, when applied to an $N \times 1$ vector $h$, shifts entries in rows $2$ through $N$ up one row and shifts the entry in row $1$ to row $N$. 
+serves as  a **cyclic shift**  operator that, when applied to an $N \times 1$ vector $h$, shifts entries in rows $2$ through $N$ up one row and shifts the entry in row $1$ to row $N$.
 
 
 Eigenvalues of  the cyclic shift permutation matrix $P$ defined in equation {eq}`eqn:exampleP` can be computed  by constructing
@@ -174,7 +173,7 @@ P-\lambda I=\left[\begin{array}{cccccc}
 \end{array}\right]
 $$
 
-and solving 
+and solving
 
 $$
 \textrm{det}(P - \lambda I) = (-1)^N \lambda^{N}-1=0
@@ -190,7 +189,7 @@ Thus, **singular values** of the  permutation matrix $P$ defined in equation {eq
 It can be verified that permutation matrices are orthogonal matrices:
 
 $$
-P P' = I 
+P P' = I
 $$
 
 
@@ -228,7 +227,7 @@ for i in range(4):
     print(f'𝜆{i} = {𝜆[i]:.1f} \nvec{i} = {Q[i, :]}\n')
 ```
 
-In graphs  below, we shall portray eigenvalues of a shift  permutation matrix   in the complex plane. 
+In graphs  below, we shall portray eigenvalues of a shift  permutation matrix   in the complex plane.
 
 These eigenvalues are uniformly distributed along the unit circle.
 
@@ -265,7 +264,7 @@ for i, N in enumerate([3, 4, 6, 8]):
 
 plt.show()
 ```
-For a vector of  coefficients $\{c_i\}_{i=0}^{n-1}$, eigenvectors of $P$ are also  eigenvectors of 
+For a vector of  coefficients $\{c_i\}_{i=0}^{n-1}$, eigenvectors of $P$ are also  eigenvectors of
 
 $$
 C = c_{0} I + c_{1} P + c_{2} P^{2} +\cdots + c_{N-1} P^{N-1}.
@@ -290,9 +289,9 @@ $$
 
 The matrix $F_8$ defines a  [Discete Fourier Transform](https://en.wikipedia.org/wiki/Discrete_Fourier_transform).
 
-To convert it into an orthogonal eigenvector matrix, we can simply normalize it by dividing every entry  by $\sqrt{8}$. 
+To convert it into an orthogonal eigenvector matrix, we can simply normalize it by dividing every entry  by $\sqrt{8}$.
 
- *  stare at the first column of $F_8$ above to convince yourself of this fact 
+ *  stare at the first column of $F_8$ above to convince yourself of this fact
 
 The eigenvalues corresponding to each eigenvector are $\{w^{j}\}_{j=0}^{7}$ in order.
 
@@ -347,10 +346,10 @@ for j in range(8):
 diff_arr
 ```
 
-## Associated Permutation Matrix 
+## Associated Permutation Matrix
 
 
-Next, we execute calculations to verify that the circulant matrix $C$ defined  in equation {eq}`eqn:circulant` can be written as 
+Next, we execute calculations to verify that the circulant matrix $C$ defined  in equation {eq}`eqn:circulant` can be written as
 
 
 $$
@@ -431,7 +430,7 @@ for j in range(8):
 
 The **Discrete Fourier Transform** (DFT) allows us to  represent a  discrete time sequence as a weighted sum of complex sinusoids.
 
-Consider a sequence of $N$ real number $\{x_j\}_{j=0}^{N-1}$. 
+Consider a sequence of $N$ real number $\{x_j\}_{j=0}^{N-1}$.
 
 The **Discrete Fourier Transform** maps $\{x_j\}_{j=0}^{N-1}$ into a sequence of complex numbers $\{X_k\}_{k=0}^{N-1}$
 
@@ -572,7 +571,7 @@ X = DFT(x)
 plot_magnitude(x=x, X=X)
 ```
 
-What happens if we change the last example to $x_{n}=2\cos\left(2\pi\frac{10}{40}n\right)$? 
+What happens if we change the last example to $x_{n}=2\cos\left(2\pi\frac{10}{40}n\right)$?
 
 Note that $\frac{10}{40}$ is an integer multiple of $\frac{1}{20}$.
 

--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -56,7 +56,7 @@ You can read about exchangeability [here](https://en.wikipedia.org/wiki/Exchange
 
 Because another term for **exchangeable** is **conditionally independent**,  we want   to convey an answer to the question *conditional on what?*
 
-We also tell why  an assumption of independence precludes  learning while 
+We also tell why  an assumption of independence precludes  learning while
 an assumption of conditional independence makes learning possible.
 
 Below, we'll often use
@@ -70,7 +70,6 @@ Let’s start with some imports:
 ---
 tags: [hide-output]
 ---
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, vectorize
@@ -88,7 +87,7 @@ An independently and identically distributed sequence is often abbreviated as II
 
 Two notions are involved
 
-- **independence** 
+- **independence**
 
 - **identically distributed**
 
@@ -181,7 +180,7 @@ We now drop into this setting a partially informed decision maker who knows
 
 - both $F$ and $G$, but
 
-- not the $F$ or $G$ that nature drew once-and-for-all at $t = -1$ 
+- not the $F$ or $G$ that nature drew once-and-for-all at $t = -1$
 
 So our decision maker does not know which of the two distributions nature selected.
 
@@ -306,7 +305,7 @@ Another way to say *use Bayes' Law* is to say *from a (subjective) joint distrib
 
 Let's dive into Bayes' Law in this context.
 
-Let $q$ represent the distribution that nature actually draws $w$ 
+Let $q$ represent the distribution that nature actually draws $w$
  from and let
 
 $$
@@ -519,7 +518,7 @@ distribution, and toward $1$ when $F$ is the true distribution).
 
 For example,
 in the above  example, under true distribution $F$,  $\pi$ will  be updated toward $0$ if $w$ falls into the interval
-$[0.524, 0.999]$, which occurs with probability $1 - .524 = .476$ under $F$. 
+$[0.524, 0.999]$, which occurs with probability $1 - .524 = .476$ under $F$.
 
 But this
 would occur with probability
@@ -623,7 +622,7 @@ T = 50
 π_paths_F = simulate(a=1, b=1, T=T, N=1000)
 ```
 
-In the above example,  for most paths $\pi_t \rightarrow 1$. 
+In the above example,  for most paths $\pi_t \rightarrow 1$.
 
 So Bayes' Law evidently eventually
 discovers the truth for most of our paths.
@@ -660,7 +659,7 @@ From the above graph, rates of convergence appear not to depend on whether $F$ o
 
 ### Graph of Ensemble Dynamics of $\pi_t$
 
-More insights about the dynamics of $\{\pi_t\}$ can be gleaned by computing 
+More insights about the dynamics of $\{\pi_t\}$ can be gleaned by computing
 conditional expectations of $\frac{\pi_{t+1}}{\pi_{t}}$ as functions of $\pi_t$ via integration with respect
 to the pertinent probability distribution:
 
@@ -738,7 +737,6 @@ We'll apply and dig deeper into some of the ideas presented in this lecture:
 
 * {doc}`this lecture <likelihood_ratio_process>` describes **likelihood ratio processes**
   and their role in frequentist and Bayesian statistical theories
-* {doc}`this lecture <navy_captain>` studies  whether a World War II US Navy Captain's hunch that a (frequentist) decision rule that the Navy had told 
+* {doc}`this lecture <navy_captain>` studies  whether a World War II US Navy Captain's hunch that a (frequentist) decision rule that the Navy had told
   him to use was  inferior to a sequential rule that Abraham
   Wald had not yet designed.
-

--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -52,7 +52,6 @@ Prerequisite knowledge is basic probability and linear algebra.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import quantecon as qe
@@ -128,7 +127,7 @@ $$
 Going the other way, if we take a stochastic matrix $P$, we can generate a Markov
 chain $\{X_t\}$ as follows:
 
-* draw $X_0$ from a marginal distribution $\psi$ 
+* draw $X_0$ from a marginal distribution $\psi$
 * for each $t = 0, 1, \ldots$, draw $X_{t+1}$ from $P(X_t,\cdot)$
 
 By construction, the resulting process satisfies {eq}`mpp`.
@@ -759,7 +758,7 @@ $$
 
 is a stationary distribution for $P$.
 
-If we restrict attention to the case in which only one stationary distribution exists, one way to  finding it is to solve the system 
+If we restrict attention to the case in which only one stationary distribution exists, one way to  finding it is to solve the system
 
 $$
 \psi (I_n - P) = 0
@@ -767,7 +766,7 @@ $$ (eq:eqpsifixed)
 
 for $\psi$, where $I_n$ is the $n \times n$ identity.
 
-But the zero vector solves system {eq}`eq:eqpsifixed`,  so we must proceed cautiously. 
+But the zero vector solves system {eq}`eq:eqpsifixed`,  so we must proceed cautiously.
 
 We want to impose the restriction that $\psi$ is  a probability distribution.
 
@@ -969,16 +968,16 @@ The vector $P^k h$ stores the conditional expectation $\mathbb E [ h(X_{t + k}) 
 The **law of iterated expectations** states that
 
 $$
-\mathbb E \left[ \mathbb E [ h(X_{t + k})  \mid X_t = x] \right] = \mathbb E [  h(X_{t + k}) ] 
+\mathbb E \left[ \mathbb E [ h(X_{t + k})  \mid X_t = x] \right] = \mathbb E [  h(X_{t + k}) ]
 $$
 
-where the outer $ \mathbb E$ on the left side is an unconditional distribution taken with respect to the marginal distribution  $\psi_t$ of $X_t$ 
-(again see equation {eq}`mdfmc2`).  
+where the outer $ \mathbb E$ on the left side is an unconditional distribution taken with respect to the marginal distribution  $\psi_t$ of $X_t$
+(again see equation {eq}`mdfmc2`).
 
 To verify the law of iterated expectations, use  equation {eq}`mc_cce2` to substitute $ (P^k h)(x)$ for $E [ h(X_{t + k})  \mid X_t = x]$, write
 
 $$
-\mathbb E \left[ \mathbb E [ h(X_{t + k})  \mid X_t = x] \right] = \psi_t P^k h, 
+\mathbb E \left[ \mathbb E [ h(X_{t + k})  \mid X_t = x] \right] = \psi_t P^k h,
 $$
 
 and note $\psi_t P^k h = \psi_{t+k} h = \mathbb E [  h(X_{t + k}) ] $.
@@ -1007,7 +1006,7 @@ Premultiplication by $(I - \beta P)^{-1}$ amounts to "applying the **resolvent o
 
 ## Exercises
 
-```{exercise} 
+```{exercise}
 :label: fm_ex1
 
 According to the discussion {ref}`above <mc_eg1-2>`, if a worker's employment dynamics obey the stochastic matrix
@@ -1278,7 +1277,7 @@ n = 14 # Total number of web pages (nodes)
 #  * Q[i, j] = 1 if there is a link from i to j
 #  * Q[i, j] = 0 otherwise
 Q = np.zeros((n, n), dtype=int)
-with open(infile) as f: 
+with open(infile) as f:
     edges = f.readlines()
 for edge in edges:
     from_node, to_node = re.findall('\w', edge)
@@ -1342,23 +1341,23 @@ Let $F$ be the cumulative distribution function of the normal distribution $N(0,
 The values $P(x_i, x_j)$ are computed to approximate the AR(1) process --- omitting the derivation, the rules are as follows:
 
 1. If $j = 0$, then set
-   
+
    $$
    P(x_i, x_j) = P(x_i, x_0) = F(x_0-\rho x_i + s/2)
    $$
-   
+
 1. If $j = n-1$, then set
-   
+
    $$
    P(x_i, x_j) = P(x_i, x_{n-1}) = 1 - F(x_{n-1} - \rho x_i - s/2)
    $$
-   
+
 1. Otherwise, set
-   
+
    $$
    P(x_i, x_j) = F(x_j - \rho x_i + s/2) - F(x_j - \rho x_i - s/2)
    $$
-   
+
 
 The exercise is to write a function `approx_markov(rho, sigma_u, m=3, n=7)` that returns
 $\{x_0, \ldots, x_{n-1}\} \subset \mathbb R$ and $n \times n$ matrix

--- a/lectures/ge_arrow.md
+++ b/lectures/ge_arrow.md
@@ -21,8 +21,8 @@ kernelspec:
 This lecture presents Python code for experimenting with  competitive equilibria of  an infinite-horizon pure exchange economy with
 
 * Heterogeneous agents
-  
-* Endowments of a single consumption that are person-specific functions of a common Markov state 
+
+* Endowments of a single consumption that are person-specific functions of a common Markov state
 
 * Complete markets in one-period Arrow state-contingent securities
 
@@ -40,7 +40,7 @@ We impose  restrictions that allow us to **Bellmanize** competitive equilibrium 
 
 We use  Bellman equations  to describe
 
-* asset prices 
+* asset prices
 
 * continuation wealth levels for each person
 
@@ -50,14 +50,14 @@ We use  Bellman equations  to describe
 In the course of presenting the model we shall describe these important ideas
 
 *  a **resolvent operator**   widely  used in this class of models
-  
+
 * absence of  **borrowing limits** in finite horizon economies
 
 * state-by-state **borrowing limits** required in infinite horizon economies
 
 * a counterpart of the **law of iterated expectations** known as a **law of iterated values**
 
-* a  **state-variable degeneracy** that prevails within a competitive equilibrium and that opens the way to various appearances of resolvent operators 
+* a  **state-variable degeneracy** that prevails within a competitive equilibrium and that opens the way to various appearances of resolvent operators
 
 
 +++
@@ -69,7 +69,7 @@ In effect, this lecture implements a Python version of  the model presented in s
 ### Preferences and endowments
 
 In each period $t\geq 0$,  a stochastic
-event $s_t \in {\bf S}$ is realized. 
+event $s_t \in {\bf S}$ is realized.
 
 Let the history of events up until time $t$
 be denoted $s^t = [s_0, s_{1}, \ldots, s_{t-1}, s_t]$.
@@ -89,8 +89,8 @@ which we capture by setting $\pi_0(s_0)=1$ for the initially
 given value of $s_0$.
 
 In this lecture we shall follow much macroeconomics and econometrics and assume that
-$\pi_t(s^t)$  is induced by  a Markov process. 
- 
+$\pi_t(s^t)$  is induced by  a Markov process.
+
 
 There are $K$ consumers named $k=1, \ldots , K$.
 
@@ -104,24 +104,24 @@ The history $s^t$ is publicly observable.
 
 Consumer $i$
 purchases a history-dependent  consumption plan $c^k =
- \{c_t^k(s^t)\}_{t=0}^\infty$ 
- 
+ \{c_t^k(s^t)\}_{t=0}^\infty$
+
 Consumer $i$  orders consumption plans by
 
 $$ U_k(c^k) =
    \sum_{t=0}^\infty \sum_{s^t} \beta^t u_k[c_t^k(s^t)]
    \pi_t(s^t),
   $$
-  
+
 where $0 < \beta < 1$.
 
 The right side is equal to $ E_0 \sum_{t=0}^\infty \beta^t
 u_k(c_t^k) $, where $E_0$ is the mathematical expectation operator,
-conditioned on $s_0$. 
+conditioned on $s_0$.
 
 Here $u_k(c)$ is an increasing, twice
 continuously differentiable, strictly concave function of
-consumption $c\geq 0$  of one good. 
+consumption $c\geq 0$  of one good.
 
 The utility function pf person $k$ satisfies
 the Inada condition
@@ -130,7 +130,7 @@ $$ \lim_{c \downarrow 0} u'_k(c) = +\infty.$$
 
 This condition implies that each
 agent chooses strictly positive consumption for every
-date-history pair $(t, s^t)$. 
+date-history pair $(t, s^t)$.
 
 Those interior solutions enable us to confine our
 analysis to Euler equations that hold with equality and also guarantee that
@@ -145,7 +145,7 @@ that  consumers share   probabilities $\pi_t(s^t)$  for all $t$ and $s^t$.
 A **feasible allocation** satisfies
 
 $$
-\sum_i c_t^k(s^t) \leq \sum_i y_t^k(s^t) 
+\sum_i c_t^k(s^t) \leq \sum_i y_t^k(s^t)
 $$
 
 for all $t$ and for all $s^t$.
@@ -159,7 +159,7 @@ Following descriptions in section 9.3.3 of Ljungqvist and Sargent {cite}`Ljungqv
 
 
 When  endowments $y^k(s)$ are all functions of a common Markov state $s$,
-the pricing kernel takes the form $Q(s'|s)$, where $Q(s'| s)$ is the price of one unit of consumption 
+the pricing kernel takes the form $Q(s'|s)$, where $Q(s'| s)$ is the price of one unit of consumption
 in state $s'$ at date $t+1$ when the Markov state at date $t$ is $s$.
 
 These enable us to provide a
@@ -172,21 +172,21 @@ Let $v^k(a,s)$ be the optimal value of consumer $i$'s problem
 starting from state $(a, s)$.
 
  * $v^k(a,s)$ is the maximum expected discounted utility  that consumer $i$ with current financial wealth $a$ can attain in Markov state $s$.
- 
+
 The optimal  value function satisfies the Bellman equation
 
 $$
 v^k(a, s) = \max_{c, \hat a(s')} \left\{ u_k(c) + \beta \sum_{s'} v^k[\hat a(s'),s'] \pi (s' | s) \right\}
-$$ 
+$$
 
 
 where  maximization is subject to the budget constraint
 
 $$
 c + \sum_{s'} \hat a(s') Q(s' | s)
-     \leq  y^k(s) + a    
+     \leq  y^k(s) + a
      $$
-     
+
 and also the constraints
 
 $$
@@ -202,14 +202,14 @@ Note that the value function and decision rule that solve  the Bellman equation 
 on the pricing kernel $Q(\cdot \vert \cdot)$ because it appears in the agent's budget constraint.
 
 Use the first-order conditions for  the
-problem on the right of the Bellman  equation and a 
+problem on the right of the Bellman  equation and a
 Benveniste-Scheinkman formula and rearrange to get
 
-$$ 
+$$
 Q(s_{t+1} | s_t ) = {\beta u'_k(c_{t+1}^k) \pi(s_{t+1} | s_t)
-                 \over u'_k(c_t^k) }, 
+                 \over u'_k(c_t^k) },
                  $$
-                 
+
 where it is understood that $c_t^k = c^k(s_t)$
 and $c_{t+1}^k = c^k(s_{t+1})$.
 
@@ -238,18 +238,18 @@ $\sum_i \hat a_{t+1}^k(s') = 0$
 for all $t$ and $s'$.
 
 * The initial financial wealth vector $\vec a_0$ satisfies $\sum_{i=1}^K a_0^k = 0 $.
- 
- 
+
+
 The third condition asserts that there are  zero net aggregate claims in all Markov states.
 
-The fourth condition asserts that the economy is closed and  starts  from a situation in which there 
+The fourth condition asserts that the economy is closed and  starts  from a situation in which there
 are  zero net aggregate claims.
 
 
 
 ## State Variable Degeneracy
 
-Please see Ljungqvist and Sargent {cite}`Ljungqvist2012` for a description of 
+Please see Ljungqvist and Sargent {cite}`Ljungqvist2012` for a description of
 timing protocol for trades  consistent with an  Arrow-Debreu vision in which
 
   * at time $0$ there are complete markets in a complete menu of history $s^t$-contingent claims on consumption at all dates that all trades occur at time zero
@@ -258,11 +258,11 @@ timing protocol for trades  consistent with an  Arrow-Debreu vision in which
 
 If  an allocation and pricing kernel $Q$ in   a recursive competitive equilibrium are to be
 consistent
-with the equilibrium allocation and price system that prevail in a  corresponding complete markets economy with such history-contingent commodities and 
+with the equilibrium allocation and price system that prevail in a  corresponding complete markets economy with such history-contingent commodities and
  all trades occurring at time $0$,
-we must impose that $a_0^k = 0$ for $k = 1, \ldots , K$. 
+we must impose that $a_0^k = 0$ for $k = 1, \ldots , K$.
 
-That  is 
+That  is
 what assures that at time $0$ the present value of each agent's consumption equals the present value of his endowment stream,
 the  single  budget constraint in   arrangement with all trades occurring at time $0$.
 
@@ -278,12 +278,12 @@ Although two state variables $a,s$ appear in the value function $v^k(a,s)$, with
 
 *  $a_0^k = 0 $ for all $i$ whenever the Markov state $s_t$ returns to   $s_0$.
 
-* Financial wealth $a$ is an exact function of the Markov state $s$.  
+* Financial wealth $a$ is an exact function of the Markov state $s$.
 
 The first finding  asserts that each household  recurrently visits the zero financial wealth state with which it began life.
 
 
-The second finding  asserts that within a competitive equilibrium  the exogenous Markov state is all we require to track an individual.  
+The second finding  asserts that within a competitive equilibrium  the exogenous Markov state is all we require to track an individual.
 
 Financial wealth turns out to be redundant because it is an exact function of the Markov state for each individual.
 
@@ -294,7 +294,7 @@ For example, it does not prevail in the incomplete markets setting of this lectu
 
 +++
 
-## Markov Asset Prices 
+## Markov Asset Prices
 
 
 Let's start with a brief summary of formulas for computing asset prices in
@@ -313,7 +313,7 @@ $$
 
 
 
-* An $n \times n$ matrix  pricing kernel $Q$ for one-period Arrow securities, where $ Q_{ij}$  = price at time $t$ in state $s_t = 
+* An $n \times n$ matrix  pricing kernel $Q$ for one-period Arrow securities, where $ Q_{ij}$  = price at time $t$ in state $s_t =
 \bar s_i$ of one unit of consumption when $s_{t+1} = \bar s_j$ at time $t+1$:
 
 
@@ -338,16 +338,16 @@ Two examples would be
 
 We'll write down implications of  Markov asset pricing in a nutshell for two types of assets
 
-  * the price in Markov state $s$ at time $t$ of a **cum dividend** stock that entitles the owner at the beginning of time $t$ to the time $t$ dividend and the option to sell the asset at time $t+1$.  The price evidently satisfies $p^h(\bar s_i) = d^h(\bar s_i) + \sum_j Q_{ij} p^h(\bar s_j) $, which implies that the vector $p^h$ satisfies $p^h = d^h + Q p^h$ which implies the formula 
-  
+  * the price in Markov state $s$ at time $t$ of a **cum dividend** stock that entitles the owner at the beginning of time $t$ to the time $t$ dividend and the option to sell the asset at time $t+1$.  The price evidently satisfies $p^h(\bar s_i) = d^h(\bar s_i) + \sum_j Q_{ij} p^h(\bar s_j) $, which implies that the vector $p^h$ satisfies $p^h = d^h + Q p^h$ which implies the formula
+
 $$
 p^h = (I - Q)^{-1} d^h
 $$
 
 
-* the price in Markov state $s$ at time $t$ of an **ex dividend** stock that entitles the owner at the end  of time $t$ to the time $t+1$ dividend and the option to sell the stock at time $t+1$. The  price is 
+* the price in Markov state $s$ at time $t$ of an **ex dividend** stock that entitles the owner at the end  of time $t$ to the time $t+1$ dividend and the option to sell the stock at time $t+1$. The  price is
 
-$$ 
+$$
 p^h = (I - Q)^{-1} Q d^h
 $$
 
@@ -360,7 +360,7 @@ In constructing our model, we'll repeatedly encounter formulas that remind us of
 
 ### Multi-Step-Forward Transition Probabilities and Pricing Kernels
 
-The $(i,j)$ component of  the $k$-step ahead transition probability $P^\ell$ is 
+The $(i,j)$ component of  the $k$-step ahead transition probability $P^\ell$ is
 
 $$
 Prob(s_{t+\ell} = \bar s_j | s_t = \bar s_i)   = P^{\ell}_{i,j}
@@ -396,7 +396,7 @@ on $s_t$ via the following string of equalities
 
 $$
 \begin{aligned}
-E \left[ E d(s_{t+j}) | s_{t+1} \right] | s_t 
+E \left[ E d(s_{t+j}) | s_{t+1} \right] | s_t
     & = \sum_{s_{t+1}} \left[ \sum_{s_{t+j}} d(s_{t+j}) P_{j-1}(s_{t+j}| s_{t+1} ) \right]         P(s_{t+1} | s_t) \\
  & = \sum_{s_{t+j}}  d(s_{t+j}) \left[ \sum_{s_{t+1}} P_{j-1} ( s_{t+j} |s_{t+1}) P(s_{t+1}| s_t) \right] \\
  & = \sum_{s_{t+j}} d(s_{t+j}) P_j (s_{t+j} | s_t ) \\
@@ -412,11 +412,11 @@ $$
 
 
 The time $t$ **value** in Markov state $s_t$  of a time $t+j$  payout $d(s_{t+j})$
-is 
+is
 
 
 $$
-V(d(s_{t+j})|s_t) = \sum_{s_{t+j}} d(s_{t+j}) Q_j(s_{t+j}| s_t) 
+V(d(s_{t+j})|s_t) = \sum_{s_{t+j}} d(s_{t+j}) Q_j(s_{t+j}| s_t)
 $$
 
 The **law of iterated values** states
@@ -430,7 +430,7 @@ to verify the law of iterated expectations:
 
 $$
 \begin{aligned}
-V \left[ V  ( d(s_{t+j}) | s_{t+1} ) \right] | s_t 
+V \left[ V  ( d(s_{t+j}) | s_{t+1} ) \right] | s_t
     & = \sum_{s_{t+1}} \left[ \sum_{s_{t+j}} d(s_{t+j}) Q_{j-1}(s_{t+j}| s_{t+1} ) \right]         Q(s_{t+1} | s_t) \\
  & = \sum_{s_{t+j}}  d(s_{t+j}) \left[ \sum_{s_{t+1}} Q_{j-1} ( s_{t+j} |s_{t+1}) Q(s_{t+1}| s_t) \right] \\
  & = \sum_{s_{t+j}} d(s_{t+j}) Q_j (s_{t+j} | s_t ) \\
@@ -440,7 +440,7 @@ $$
 
 +++
 
-## General Equilibrium 
+## General Equilibrium
 
 Now we are ready to do some fun calculations.
 
@@ -465,13 +465,13 @@ $$
 * A collection of restrictions  on feasible consumption allocations for $s \in S$:
 
 $$
-c\left(s\right)= \sum_{k=1}^K c^k\left(s\right) 
-\leq  y\left(s\right) 
+c\left(s\right)= \sum_{k=1}^K c^k\left(s\right)
+\leq  y\left(s\right)
 $$
 
 * Preferences: a common utility functional across agents $ E_0 \sum_{t=0}^\infty \beta^t u(c^k_t) $ with  CRRA one-period utility function $u\left(c\right)$ and discount factor $\beta \in (0,1)$
 
-The one-period utility function is 
+The one-period utility function is
 
 $$
 u \left(c\right) = \frac{c^{1-\gamma}}{1-\gamma}
@@ -485,7 +485,7 @@ $$
 
 ### Outputs
 
-* An $n \times n$ matrix  pricing kernel $Q$ for one-period Arrow securities, where $ Q_{ij}$  = price at time $t$ in state $s_t = \bar s_i$ of one unit of consumption when $s_{t+1} = \bar s_j$ at time $t+1$ 
+* An $n \times n$ matrix  pricing kernel $Q$ for one-period Arrow securities, where $ Q_{ij}$  = price at time $t$ in state $s_t = \bar s_i$ of one unit of consumption when $s_{t+1} = \bar s_j$ at time $t+1$
 
 * pure exchange so that $c\left(s\right) = y\left(s\right)$
 
@@ -515,20 +515,20 @@ with aggregate consumption and therefore with the aggregate endowment.
 
   * This is a consequence of our preference specification implying that **Engle curves** affine in wealth and therefore  satisfy conditions for **Gorman aggregation**
 
-Thus, 
+Thus,
 
 $$
 c^k \left(s\right) = \alpha_k c\left(s\right) = \alpha_k y\left(s\right)
 $$
 
-for an arbitrary   **distribution of wealth**  in the form of an   $K \times 1$ vector $\alpha$ 
+for an arbitrary   **distribution of wealth**  in the form of an   $K \times 1$ vector $\alpha$
 that satisfies
 
 $$ \alpha_k \in \left(0, 1\right), \quad \sum_{k=1}^K \alpha_k = 1 $$
 
 +++
 
-This means that we can compute the pricing kernel from  
+This means that we can compute the pricing kernel from
 
 $$
 Q_{ij} = \beta \left(\frac{y_j}{y_i}\right)^{-\gamma} P_{ij}
@@ -543,11 +543,11 @@ Note that $Q_{ij}$ is independent of vector $\alpha$.
 
 +++
 
-### Values 
+### Values
 
 
 Having computed an equilibrium pricing kernel $Q$, we can compute several **values** that are required
-to pose or represent the solution of an individual household's optimum problem. 
+to pose or represent the solution of an individual household's optimum problem.
 
 
 We denote  an $K \times 1$ vector of  state-dependent values of agents' endowments in Markov state $s$ as
@@ -588,7 +588,7 @@ $$
 
 
 In a competitive equilibrium of an **infinite horizon** economy with sequential trading of one-period Arrow securities, $A^k(s)$ serves as a state-by-state vector of **debt limits** on the quantities of one-period  Arrow securities
-paying off  in state $s$ at time $t+1$ that individual $k$ can issue at time $t$.  
+paying off  in state $s$ at time $t+1$ that individual $k$ can issue at time $t$.
 
 
 These are often called **natural debt limits**.
@@ -596,8 +596,8 @@ These are often called **natural debt limits**.
 Evidently, they equal the maximum amount that it is feasible for  individual $k$ to repay
 even if he consumes zero goods forevermore.
 
-**Remark:** If  we have an Inada condition at zero consumption or just impose that consumption 
-be nonnegative, then in a **finite horizon** economy with sequential trading of one-period Arrow securities there is no need to impose natural debt limits. See the section below on a Finite Horizon Economy. 
+**Remark:** If  we have an Inada condition at zero consumption or just impose that consumption
+be nonnegative, then in a **finite horizon** economy with sequential trading of one-period Arrow securities there is no need to impose natural debt limits. See the section below on a Finite Horizon Economy.
 
 +++
 
@@ -653,7 +653,7 @@ Note that $\sum_{k=1}^K \psi^k = {0}_{n \times 1}$.
 
 **Remark:** At the initial state $s_0 \in \begin{bmatrix} \bar s_1, \ldots, \bar s_n \end{bmatrix}$,
 the continuation wealth $\psi^k(s_0) = 0$ for all agents $k = 1, \ldots, K$.  This indicates that
-the economy begins with  all agents being debt-free and financial-asset-free at time $0$, state $s_0$.  
+the economy begins with  all agents being debt-free and financial-asset-free at time $0$, state $s_0$.
 
 
 **Remark:** Note that all agents' continuation wealths recurrently return to zero when the Markov state returns to whatever value $s_0$ it had at time $0$.
@@ -667,7 +667,7 @@ A nifty feature of the model is that an optimal portfolio of  a type $k$ agent e
 Thus, agent $k$'s state-by-state purchases of Arrow securities next period depend only on next period's
 Markov state and equal
 
-$$ 
+$$
 a_k(s) = \psi^k(s), \quad s \in \left[\bar s_1, \ldots, \bar s_n \right]
 $$ (eqn:optport)
 
@@ -676,7 +676,7 @@ $$ (eqn:optport)
 ### Equilibrium Wealth Distribution $\alpha$
 
 
-With the initial state being  a particular state $s_0 \in \left[\bar{s}_1, \ldots, \bar{s}_n\right]$, 
+With the initial state being  a particular state $s_0 \in \left[\bar{s}_1, \ldots, \bar{s}_n\right]$,
 we must have
 
 $$
@@ -691,7 +691,7 @@ $$ (eqn:alphakform)
 
 
 
-where $V \equiv \left[I - Q\right]^{-1}$ and $z$ is the row index corresponding to the initial state $s_0$. 
+where $V \equiv \left[I - Q\right]^{-1}$ and $z$ is the row index corresponding to the initial state $s_0$.
 
 Since $\sum_{k=1}^K V_z y^k = V_z y$,  $\sum_{k=1}^K \alpha_k = 1$.
 
@@ -713,13 +713,13 @@ In summary, here is the logical flow of an algorithm to compute a competitive eq
 We can also add formulas for optimal value functions in  a competitive equilibrium with trades
 in a complete set of one-period state-contingent Arrow securities.
 
-Call the optimal value functions $J^k$ for consumer $k$. 
+Call the optimal value functions $J^k$ for consumer $k$.
 
 For the infinite horizon economy now under study, the formula is
 
 $$ J^k = (I - \beta P)^{-1} u(\alpha_k y)  , \quad u(c) = \frac{c^{1-\gamma}}{1-\gamma} $$
 
-where it is understood that $ u(\alpha_k y)$ is a vector. 
+where it is understood that $ u(\alpha_k y)$ is a vector.
 
 
 
@@ -735,7 +735,6 @@ As usual, we start with Python imports.
 ```{code-cell} ipython3
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ```{code-cell} ipython3
@@ -746,7 +745,7 @@ np.set_printoptions(suppress=True)
 First, we create a Python class to compute  the objects that comprise a competitive equilibrium
 with sequential trading of one-period Arrow securities.
 
-In addition to  handly infinite-horizon economies, the code is set up to handle finite-horizon economies indexed by horizon $T$. 
+In addition to  handly infinite-horizon economies, the code is set up to handle finite-horizon economies indexed by horizon $T$.
 
 We'll study some finite horizon economies after we look at some infinite-horizon economies.
 
@@ -780,10 +779,10 @@ class RecurCompetitive:
 
         # compute pricing kernel
         self.Q = self.pricing_kernel()
-        
+
         # compute price of risk-free one-period bond
         self.PRF = self.price_risk_free_bond()
-        
+
         # compute risk-free rate
         self.R = self.risk_free_rate()
 
@@ -866,12 +865,12 @@ class RecurCompetitive:
 
     def price_risk_free_bond(self):
         "Give Q, compute price of one-period risk free bond"
-        
+
         PRF = np.sum(self.Q, 0)
         self.PRF = PRF
-        
+
         return PRF
-    
+
     def risk_free_rate(self):
         "Given Q, compute one-period gross risk-free interest rate R"
 
@@ -916,7 +915,7 @@ class RecurCompetitive:
 
 ### Example 1
 
-Please read the preceding class for default parameter values and the  following Python code for the fundamentals of the economy.  
+Please read the preceding class for default parameter values and the  following Python code for the fundamentals of the economy.
 
 Here goes.
 
@@ -1182,21 +1181,21 @@ for i in range(1, 4):
     print(f'J = \n{ex4.value_functionss()}\n')
 ```
 
-## Finite Horizon 
+## Finite Horizon
 
 The Python class **RecurCompetitive** provided above also can be used to compute competitive equilibrium
-allocations and Arrow securities prices for finite horizon economies.  
+allocations and Arrow securities prices for finite horizon economies.
 
-The setting is a finite-horizon version of  the one above except that time now runs for $T+1$ periods 
-$t \in {\bf T} = \{ 0, 1, \ldots, T\}$.  
+The setting is a finite-horizon version of  the one above except that time now runs for $T+1$ periods
+$t \in {\bf T} = \{ 0, 1, \ldots, T\}$.
 
 Consequently, we want  $T+1$ counterparts to objects described above, with one important exception:
 we won't need **borrowing limits**.
 
  * borrowing limits aren't required for a finite horizon economy in which a
-one-period utility function $u(c)$ satisfies an Inada condition that sets the marginal utility of consumption at zero consumption to zero.  
+one-period utility function $u(c)$ satisfies an Inada condition that sets the marginal utility of consumption at zero consumption to zero.
  * Nonnegativity of consumption choices at all $t \in {\bf T}$ automatically
-limits borrowing. 
+limits borrowing.
 
 
 ### Continuation Wealths
@@ -1251,9 +1250,9 @@ $$
 
 Note that $\sum_{k=1}^K \psi_t^k = {0}_{n \times 1}$ for all $t \in {\bf T}$.
 
-**Remark:** At the initial state $s_0 \in \begin{bmatrix} \bar s_1, \ldots, \bar s_n \end{bmatrix}$, 
+**Remark:** At the initial state $s_0 \in \begin{bmatrix} \bar s_1, \ldots, \bar s_n \end{bmatrix}$,
  for all agents $k = 1, \ldots, K$, continuation wealth $\psi_0^k(s_0) = 0$.  This indicates that
-the economy begins with  all agents being debt-free and financial-asset-free at time $0$, state $s_0$.  
+the economy begins with  all agents being debt-free and financial-asset-free at time $0$, state $s_0$.
 
 
 **Remark:** Note that all agents' continuation wealths  return to zero when the Markov state returns to whatever value $s_0$ it had at time $0$. This will recur if the Markov chain makes the initial state $s_0$ recurrent.
@@ -1275,13 +1274,13 @@ $$ (eq:w)
 
 
 
-where  now in our finite-horizon economy  
+where  now in our finite-horizon economy
 
 $$
  V = \left[I + Q + Q^2 + \cdots + Q^T \right]
 $$ (eq:ww)
 
-and $z$ is the row index corresponding to the initial state $s_0$. 
+and $z$ is the row index corresponding to the initial state $s_0$.
 
 Since $\sum_{k=1}^K V_z y^k = V_z y$,  $\sum_{k=1}^K \alpha_k = 1$.
 
@@ -1308,7 +1307,7 @@ for the finite horizon economy the formula is
 
 $$ J_0^k = (I + \beta P + \cdots + \beta^T P^T) u(\alpha_k y) , $$
 
-where it is understood that $ u(\alpha_k y)$ is a vector.  
+where it is understood that $ u(\alpha_k y)$ is a vector.
 
 
 +++

--- a/lectures/ge_arrow.md
+++ b/lectures/ge_arrow.md
@@ -14,8 +14,6 @@ kernelspec:
 
 # Competitive Equilibria with Arrow Securities
 
-+++
-
 ## Introduction
 
 This lecture presents Python code for experimenting with  competitive equilibria of  an infinite-horizon pure exchange economy with
@@ -58,9 +56,6 @@ In the course of presenting the model we shall describe these important ideas
 * a counterpart of the **law of iterated expectations** known as a **law of iterated values**
 
 * a  **state-variable degeneracy** that prevails within a competitive equilibrium and that opens the way to various appearances of resolvent operators
-
-
-+++
 
 ## The setting
 
@@ -149,8 +144,6 @@ $$
 $$
 
 for all $t$ and for all $s^t$.
-
-+++
 
 ## Recursive Formulation
 
@@ -292,8 +285,6 @@ This outcome depends critically on there being complete markets in Arrow securit
 
 For example, it does not prevail in the incomplete markets setting of this lecture {doc}`The Aiyagari Model <aiyagari>`
 
-+++
-
 ## Markov Asset Prices
 
 
@@ -355,8 +346,6 @@ $$
 Below, we describe an equilibrium model with trading of one-period Arrow securities in which the pricing kernel is endogenous.
 
 In constructing our model, we'll repeatedly encounter formulas that remind us of our asset pricing formulas.
-
-+++
 
 ### Multi-Step-Forward Transition Probabilities and Pricing Kernels
 
@@ -438,15 +427,11 @@ V \left[ V  ( d(s_{t+j}) | s_{t+1} ) \right] | s_t
     \end{aligned}
 $$
 
-+++
-
 ## General Equilibrium
 
 Now we are ready to do some fun calculations.
 
 We find it interesting to think in terms of analytical **inputs** into and **outputs** from our general equilibrium theorizing.
-
-+++
 
 ### Inputs
 
@@ -493,8 +478,6 @@ $$
 
 * A collection of $n \times 1$ vectors of individual $k$ consumptions: $c^k\left(s\right), k=1,\ldots, K$
 
-+++
-
 ### $Q$ is the Pricing Kernel
 
 
@@ -526,8 +509,6 @@ that satisfies
 
 $$ \alpha_k \in \left(0, 1\right), \quad \sum_{k=1}^K \alpha_k = 1 $$
 
-+++
-
 This means that we can compute the pricing kernel from
 
 $$
@@ -540,8 +521,6 @@ Note that $Q_{ij}$ is independent of vector $\alpha$.
 
 
 **Key finding:** We can compute competitive equilibrium **prices** prior to computing a **distribution of wealth**.
-
-+++
 
 ### Values
 
@@ -599,8 +578,6 @@ even if he consumes zero goods forevermore.
 **Remark:** If  we have an Inada condition at zero consumption or just impose that consumption
 be nonnegative, then in a **finite horizon** economy with sequential trading of one-period Arrow securities there is no need to impose natural debt limits. See the section below on a Finite Horizon Economy.
 
-+++
-
 ### Continuation Wealth
 
 Continuation wealth plays an important role in Bellmanizing a competitive equilibrium with sequential
@@ -626,8 +603,6 @@ $$
 \psi^{k}\left(\bar{s}_{n}\right)
 \end{array}\right], \quad k \in \left[1, \ldots, K\right]
 $$
-
-+++
 
 Continuation wealth  $\psi^k$ of consumer $k$ satisfies
 
@@ -658,8 +633,6 @@ the economy begins with  all agents being debt-free and financial-asset-free at 
 
 **Remark:** Note that all agents' continuation wealths recurrently return to zero when the Markov state returns to whatever value $s_0$ it had at time $0$.
 
-+++
-
 ### Optimal Portfolios
 
 A nifty feature of the model is that an optimal portfolio of  a type $k$ agent equals the continuation wealth that we just computed.
@@ -670,8 +643,6 @@ Markov state and equal
 $$
 a_k(s) = \psi^k(s), \quad s \in \left[\bar s_1, \ldots, \bar s_n \right]
 $$ (eqn:optport)
-
-+++
 
 ### Equilibrium Wealth Distribution $\alpha$
 
@@ -708,8 +679,6 @@ In summary, here is the logical flow of an algorithm to compute a competitive eq
 
 * via formula {eq}`eqn:optport` equate agent $k$'s portfolio to its continuation wealth state by state
 
-+++
-
 We can also add formulas for optimal value functions in  a competitive equilibrium with trades
 in a complete set of one-period state-contingent Arrow securities.
 
@@ -720,10 +689,6 @@ For the infinite horizon economy now under study, the formula is
 $$ J^k = (I - \beta P)^{-1} u(\alpha_k y)  , \quad u(c) = \frac{c^{1-\gamma}}{1-\gamma} $$
 
 where it is understood that $ u(\alpha_k y)$ is a vector.
-
-
-
-+++
 
 ## Python Code
 
@@ -1308,9 +1273,6 @@ for the finite horizon economy the formula is
 $$ J_0^k = (I + \beta P + \cdots + \beta^T P^T) u(\alpha_k y) , $$
 
 where it is understood that $ u(\alpha_k y)$ is a vector.
-
-
-+++
 
 ### Finite Horizon Example
 

--- a/lectures/geom_series.md
+++ b/lectures/geom_series.md
@@ -49,7 +49,6 @@ These and other applications prove the truth of the wise crack that
 Below we'll use the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -59,7 +59,6 @@ import matplotlib.pyplot as plt
 from scipy.signal import fftconvolve
 from tabulate import tabulate
 import time
-%matplotlib inline
 ```
 
 

--- a/lectures/ifp.md
+++ b/lectures/ifp.md
@@ -59,7 +59,6 @@ Time iteration is globally convergent under mild assumptions, even when utility 
 We'll need the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -56,7 +56,6 @@ endogenous grid method to solve the model quickly and accurately.
 We require the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/imp_sample.md
+++ b/lectures/imp_sample.md
@@ -33,7 +33,6 @@ We start by importing some Python packages.
 import numpy as np
 from numba import njit, vectorize, prange
 import matplotlib.pyplot as plt
-%matplotlib inline
 from math import gamma
 ```
 

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -47,7 +47,6 @@ While our Markov environment and many of the concepts we consider are related to
 Let's start with some imports
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -33,7 +33,6 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!pip install quantecon
 !pip install interpolation
 ```
 

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -46,7 +46,6 @@ In this section, we solve a simple on-the-job search model
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/kalman.md
+++ b/lectures/kalman.md
@@ -55,7 +55,6 @@ Required knowledge: Familiarity with matrix manipulations, multivariate normal d
 We'll need the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from scipy import linalg

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -54,7 +54,6 @@ We will discuss these issues as we go along.
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -68,7 +68,6 @@ These concepts will help us build an equilibrium model of ex-ante homogeneous wo
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -49,7 +49,6 @@ We'll begin by loading some Python modules.
 ```{code-cell} ipython3
 :hide-output: false
 
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -388,8 +387,8 @@ $g$.
 ## Behavior of  posterior probability $\{\pi_t\}$  under the subjective probability distribution
 
 
-We'll end this lecture by briefly studying what our Baysian learner expects to learn under the 
-subjective beliefs $\pi_t$ cranked out by Bayes' law.  
+We'll end this lecture by briefly studying what our Baysian learner expects to learn under the
+subjective beliefs $\pi_t$ cranked out by Bayes' law.
 
 This will provide us with some perspective  on our application of  Bayes's law as a theory of learning.
 
@@ -397,21 +396,21 @@ As we shall see, at each time $t$, the Bayesian learner knows that he will be su
 
 But he expects that new information will not lead him  to change his beliefs.
 
-And it won't on average under his subjective beliefs.  
+And it won't on average under his subjective beliefs.
 
 We'll continue with our setting in which a McCall worker  knows that successive
 draws of his wage are drawn from either $F$ or $G$, but  does not know which of these two  distributions
 nature has drawn once-and-for-all before time $0$.
 
-We'll review and reiterate and rearrange some formulas that we have encountered above and in associated lectures. 
+We'll review and reiterate and rearrange some formulas that we have encountered above and in associated lectures.
 
 The worker's initial beliefs induce a joint probability distribution
- over a potentially infinite sequence of draws $w_0, w_1, \ldots $. 
- 
+ over a potentially infinite sequence of draws $w_0, w_1, \ldots $.
+
 Bayes' law is simply an application of  laws of
- probability to compute the conditional distribution of the $t$th draw $w_t$ conditional on $[w_0, \ldots, w_{t-1}]$. 
- 
-After our worker puts a subjective probability $\pi_{-1}$ on nature having selected distribution $F$, we have in effect assumes from the start that the   decision maker **knows** the joint distribution  for the process $\{w_t\}_{t=0}$.  
+ probability to compute the conditional distribution of the $t$th draw $w_t$ conditional on $[w_0, \ldots, w_{t-1}]$.
+
+After our worker puts a subjective probability $\pi_{-1}$ on nature having selected distribution $F$, we have in effect assumes from the start that the   decision maker **knows** the joint distribution  for the process $\{w_t\}_{t=0}$.
 
 We assume that the worker also knows the laws of probability theory.
 
@@ -420,21 +419,21 @@ A respectable view is that Bayes' law is less a theory of learning than a statem
 
 ### Mechanical details again
 
-At time $0$ **before** drawing a wage offer, the worker attaches probability $\pi_{-1} \in (0,1)$ to the distribution being $F$.  
- 
+At time $0$ **before** drawing a wage offer, the worker attaches probability $\pi_{-1} \in (0,1)$ to the distribution being $F$.
+
 Before drawing a wage at time $0$, the  worker thus believes that the density of $w_0$
-is 
+is
 
 $$
 h(w_0;\pi_{-1}) = \pi_{-1} f(w_0) + (1-\pi_{-1}) g(w_0).
 $$
 
-Let $a \in \{ f, g\} $ be an index that indicates whether  nature chose permanently to draw from distribution $f$ or from distribution $g$. 
+Let $a \in \{ f, g\} $ be an index that indicates whether  nature chose permanently to draw from distribution $f$ or from distribution $g$.
 
 After drawing $w_0$, the worker uses Bayes' law to deduce that
 the posterior  probability $\pi_0 = {\rm Prob}{a = f | w_0} $
 that the density is $f(w)$ is
- 
+
 $$
 \pi_0 = { \pi_{-1} f(w_0) \over \pi_{-1} f(w_0) + (1-\pi_{-1}) g(w_0)} .
 $$
@@ -443,8 +442,8 @@ $$
 More generally,  after making the $t$th draw and having   observed   $w_t, w_{t-1}, \ldots, w_0$, the worker believes that
 the probability that $w_{t+1}$ is  being drawn from  distribution  $F$ is
 
-$$ 
-\pi_t = \pi_t(w_t | \pi_{t-1}) \equiv { \pi_{t-1} f(w_t)/g(w_t) \over \pi_{t-1} f(w_t)/g(w_t) + (1-\pi_{t-1})} 
+$$
+\pi_t = \pi_t(w_t | \pi_{t-1}) \equiv { \pi_{t-1} f(w_t)/g(w_t) \over \pi_{t-1} f(w_t)/g(w_t) + (1-\pi_{t-1})}
 $$ (eq:like44)
 
 
@@ -452,19 +451,19 @@ or
 
 
 $$
-\pi_t=\frac{\pi_{t-1} l_t(w_t)}{\pi_{t-1} l_t(w_t)+1-\pi_{t-1}} 
+\pi_t=\frac{\pi_{t-1} l_t(w_t)}{\pi_{t-1} l_t(w_t)+1-\pi_{t-1}}
 $$
 
 
 and that the density of $w_{t+1}$ conditional on $w_t, w_{t-1}, \ldots, w_0$ is
 
 $$
-h(w_{t+1};\pi_{t}) = \pi_{t} f(w_{t+1}) + (1-\pi_{t}) g(w_{t+1}) . 
+h(w_{t+1};\pi_{t}) = \pi_{t} f(w_{t+1}) + (1-\pi_{t}) g(w_{t+1}) .
 $$
 
 Notice that
 
-$$ 
+$$
 \begin{aligned}
 E(\pi_t | \pi_{t-1}) & = \int \Bigl[  { \pi_{t-1} f(w) \over \pi_{t-1} f(w) + (1-\pi_{t-1})g(w)  } \Bigr]
  \Bigl[ \pi_{t-1} f(w) + (1-\pi_{t-1})g(w) \Bigr]  d w \cr
@@ -472,7 +471,7 @@ E(\pi_t | \pi_{t-1}) & = \int \Bigl[  { \pi_{t-1} f(w) \over \pi_{t-1} f(w) + (1
               & = \pi_{t-1}, \cr
 \end{aligned}
 $$
-              
+
 so that the process $\pi_t$ is a **martingale**.
 
 Indeed, it is a **bounded martingale** because each $\pi_t$, being a probability,
@@ -481,27 +480,27 @@ is between $0$ and $1$.
 
 In the first line in the above string of equalities, the term in the first set of brackets
 is just $\pi_t$ as a function of $w_{t}$, while the term in the second set of brackets is the density of $w_{t}$ conditional
-on $w_{t-1}, \ldots , w_0$ or equivalently conditional on the *sufficient statistic* $\pi_{t-1}$ for $w_{t-1}, \ldots , w_0$. 
+on $w_{t-1}, \ldots , w_0$ or equivalently conditional on the *sufficient statistic* $\pi_{t-1}$ for $w_{t-1}, \ldots , w_0$.
 
 Notice that here we are computing $E(\pi_t | \pi_{t-1})$ under the **subjective** density described in the second
 term in brackets.
 
-Because $\{\pi_t\}$ is a bounded martingale sequence, it follows from the **martingale convergence theorem** that $\pi_t$ converges almost surely to a random variable in $[0,1]$.  
+Because $\{\pi_t\}$ is a bounded martingale sequence, it follows from the **martingale convergence theorem** that $\pi_t$ converges almost surely to a random variable in $[0,1]$.
 
 Practically, this means that  probability one is  attached to   sample paths
- $\{\pi_t\}_{t=0}^\infty$ that  converge.  
- 
+ $\{\pi_t\}_{t=0}^\infty$ that  converge.
+
 According to the theorem,  it  different sample  paths  can converge to different limiting values.
 
 Thus, let $\{\pi_t(\omega)\}_{t=0}^\infty$ denote a particular sample path indexed by a particular $\omega
-\in \Omega$.  
+\in \Omega$.
 
 We can think of nature as drawing an $\omega \in \Omega$ from a probability distribution
 ${\textrm{Prob}} \Omega$ and then generating a single realization (or _simulation_) $\{\pi_t(\omega)\}_{t=0}^\infty$ of the process.
 
-The limit points of  $\{\pi_t(\omega)\}_{t=0}^\infty$ as $t \rightarrow +\infty$ are realizations of a random variable that  is swept out as we sample $\omega$ from $\Omega$ and construct repeated draws of $\{\pi_t(\omega)\}_{t=0}^\infty$.  
- 
- 
+The limit points of  $\{\pi_t(\omega)\}_{t=0}^\infty$ as $t \rightarrow +\infty$ are realizations of a random variable that  is swept out as we sample $\omega$ from $\Omega$ and construct repeated draws of $\{\pi_t(\omega)\}_{t=0}^\infty$.
+
+
 By staring at law of motion {eq}`eq_recur1` or {eq}`eq:like44` , we can figure out some things about the probability distribution of the limit points
 
 
@@ -514,17 +513,17 @@ $$
 
 
 Evidently, since the likelihood ratio $\ell(w_t) $ differs from $1$ when $f \neq g$,
-as we have assumed, the only possible fixed points of {eq}`eq:like44` are 
+as we have assumed, the only possible fixed points of {eq}`eq:like44` are
 
-$$ 
-\pi_\infty(\omega) =1 
+$$
+\pi_\infty(\omega) =1
 $$
 
 
-and 
+and
 
-$$ 
-\pi_\infty(\omega) =0 
+$$
+\pi_\infty(\omega) =0
 $$
 
 
@@ -534,16 +533,16 @@ while for other realizations,  $\lim_{\rightarrow + \infty} \pi_t(\omega) =0$.
 Now let's remember that $\{\pi_t\}_{t=0}^\infty$ is a martingale and apply the law of iterated expectations.
 
 
-The law of iterated expectations implies 
+The law of iterated expectations implies
 
-$$ 
+$$
 E_t \pi_{t+j}  = \pi_t
 $$
 
 and in particular
 
 $$
-E_{-1} \pi_{t+j} = \pi_{-1}. 
+E_{-1} \pi_{t+j} = \pi_{-1}.
 $$
 
 Applying the above formula to $\pi_\infty$, we obtain
@@ -564,17 +563,17 @@ $$
 and consequently that
 
 $$
-E_{-1} \pi_\infty(\omega) = \lambda \cdot 1 + (1-\lambda) \cdot 0 = \lambda 
-$$ 
+E_{-1} \pi_\infty(\omega) = \lambda \cdot 1 + (1-\lambda) \cdot 0 = \lambda
+$$
 
 
-Combining this equation with equation (20), we deduce that 
+Combining this equation with equation (20), we deduce that
 the probability that ${\textrm{Prob}(\Omega)}$ attaches to
 $\pi_\infty(\omega)$ being $1$ must be $\pi_{-1}$.
 
 
-Thus, under the worker's subjective distribution, $\pi_{-1}$ of the sample paths 
-of $\{\pi_t\}$ will converge pointwise to $1$ and $1 - \pi_{-1}$ of the sample paths will 
+Thus, under the worker's subjective distribution, $\pi_{-1}$ of the sample paths
+of $\{\pi_t\}$ will converge pointwise to $1$ and $1 - \pi_{-1}$ of the sample paths will
 converge pointwise to $0$.
 
 
@@ -594,7 +593,7 @@ We'll plot a large sample of paths.
 ```{code-cell} ipython3
 @njit
 def martingale_simulate(π0, N=5000, T=200):
-    
+
     π_path = np.empty((N,T+1))
     w_path = np.empty((N,T))
     π_path[:,0] = π0
@@ -610,17 +609,17 @@ def martingale_simulate(π0, N=5000, T=200):
             π = π*f(w)/g(w)/(π*f(w)/g(w) + 1 - π)
             π_path[n,t+1] = π
             w_path[n,t] = w
-        
+
     return π_path, w_path
 
 def fraction_0_1(π0, N, T, decimals):
-    
+
     π_path, w_path = martingale_simulate(π0, N=N, T=T)
     values, counts = np.unique(np.round(π_path[:,-1], decimals=decimals), return_counts=True)
     return values, counts
 
 def create_table(π0s, N=10000, T=500, decimals=2):
- 
+
     outcomes = []
     for π0 in π0s:
         values, counts = fraction_0_1(π0, N=N, T=T, decimals=decimals)
@@ -653,7 +652,7 @@ plt.show()
 
 
 
-The above graph indicates that 
+The above graph indicates that
 
 * each of paths converges
 
@@ -663,7 +662,7 @@ The above graph indicates that
 
 * none of the paths converge to a limit point not equal to $0$ or $1$
 
-Convergence actually occurs pretty fast, as the following graph of the cross-ensemble distribution of $\pi_t$ for various small $t$'s indicates. 
+Convergence actually occurs pretty fast, as the following graph of the cross-ensemble distribution of $\pi_t$ for various small $t$'s indicates.
 
 
 
@@ -671,7 +670,7 @@ Convergence actually occurs pretty fast, as the following graph of the cross-ens
 fig, ax = plt.subplots()
 for t in [1, 10, T-1]:
     ax.hist(π_path[:,t], bins=20, alpha=0.4, label=f'T={t}')
-    
+
 ax.set_ylabel('count')
 ax.set_xlabel('$\pi_T$')
 ax.legend(loc='lower right')
@@ -704,7 +703,7 @@ T = 200
 fig, ax = plt.subplots()
 for t in [1, 10, T-1]:
     ax.hist(π_path3[:,t], bins=20, alpha=0.4, label=f'T={t}')
-    
+
 ax.set_ylabel('count')
 ax.set_xlabel('$\pi_T$')
 ax.legend(loc='upper right')
@@ -719,7 +718,7 @@ $w_t$'s and the $\pi_t$ sequences that gave rise to them.
 
 Notice that one of the paths involves systematically higher $w_t$'s, outcomes that push $\pi_t$ upward.
 
-The luck of the draw early in a simulation push the subjective distribution to draw from 
+The luck of the draw early in a simulation push the subjective distribution to draw from
 $F$ more frequently along a sample path, and this pushes $\pi_t$ toward $0$.
 
 
@@ -729,7 +728,7 @@ fig, ax = plt.subplots()
 for i, j in enumerate([10, 100]):
     ax.plot(range(T+1), π_path[j,:], color=colors[i], label=f'$\pi$_path, {j}-th simulation')
     ax.plot(range(1,T+1), w_path[j,:], color=colors[i], label=f'$w$_path, {j}-th simulation', alpha=0.3)
-    
+
 ax.legend(loc='upper right')
 ax.set_xlabel('$t$')
 ax.set_ylabel('$\pi_t$')
@@ -742,12 +741,12 @@ plt.show()
 
 
 
-Now let's use our Python code to generate a table that checks out our earlier claims about the 
+Now let's use our Python code to generate a table that checks out our earlier claims about the
 probability distribution of the pointwise limits $\pi_{\infty}(\omega)$.
 
 We'll use our simulations to generate a histogram of this distribution.
 
-In the following table, the left column in bold face reports an assumed value of $\pi_{-1}$. 
+In the following table, the left column in bold face reports an assumed value of $\pi_{-1}$.
 
 The second column reports the fraction of $N = 10000$ simulations for which $\pi_{t}$  had converged to $0$  at the terminal date $T=500$ for each simulation.
 
@@ -766,13 +765,13 @@ The fraction of simulations for which $\pi_{t}$  had converged to $1$ is indeed 
 To understand how the local dynamics of $\pi_t$ behaves, it is enlightening to consult the  variance of $\pi_{t}$ conditional on $\pi_{t-1}$.
 
 Under the subjective distribution this conditional variance is defined as
-  
+
 $$
 \sigma^2(\pi_t | \pi_{t-1})  = \int \Bigl[  { \pi_{t-1} f(w) \over \pi_{t-1} f(w) + (1-\pi_{t-1})g(w)  } - \pi_{t-1} \Bigr]^2
  \Bigl[ \pi_{t-1} f(w) + (1-\pi_{t-1})g(w) \Bigr]  d w
 $$
 
-We can use  a Monte Carlo simulation to approximate this conditional variance. 
+We can use  a Monte Carlo simulation to approximate this conditional variance.
 
 We approximate it for  a grid of points $\pi_{t-1} \in [0,1]$.
 
@@ -783,13 +782,13 @@ Then we'll plot it.
 def compute_cond_var(pi, mc_size=int(1e6)):
     # create monte carlo draws
     mc_draws = np.zeros(mc_size)
-    
+
     for i in prange(mc_size):
         if np.random.rand() <= pi:
             mc_draws[i] = np.random.beta(F_a, F_b)
         else:
             mc_draws[i] = np.random.beta(G_a, G_b)
-    
+
     dev = pi*f(mc_draws)/(pi*f(mc_draws) + (1-pi)*g(mc_draws)) - pi
     return np.mean(dev**2)
 
@@ -816,8 +815,3 @@ The conditional variance is nearly zero only when the agent  is almost sure that
 
 This lecture has been devoted to building some useful infrastructure that will help us understand inferences that are the foundations of
 results described  in {doc}`this lecture <odu>` and {doc}`this lecture <wald_friedman>` and {doc}`this lecture <navy_captain>`.
-
-
-
-
-

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -43,7 +43,6 @@ Let's start  by importing some Python tools.
 
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -349,18 +348,18 @@ The two probabilities are:
 
 - Probability of detection (= power = 1 minus probability
   of Type II error):
-  
+
   $$
   1-\beta \equiv \Pr\left\{ L\left(w^{t}\right)<c\mid q=g\right\}
   $$
-  
+
 - Probability of false alarm (= significance level = probability of
   Type I error):
-  
+
   $$
   \alpha \equiv  \Pr\left\{ L\left(w^{t}\right)<c\mid q=f\right\}
   $$
-  
+
 
 The [Neyman-Pearson
 Lemma](https://en.wikipedia.org/wiki/Neyman–Pearson_lemma)
@@ -694,4 +693,3 @@ and as applied in {doc}`this lecture <odu>`.
 
 Likelihood ratio processes appear again in [this lecture](https://python-advanced.quantecon.org/additive_functionals.html), which contains another illustration
 of the **peculiar property** of likelihood ratio processes described above.
-

--- a/lectures/linear_algebra.md
+++ b/lectures/linear_algebra.md
@@ -73,7 +73,6 @@ material that will be used in applications as we go along.
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/linear_models.md
+++ b/lectures/linear_models.md
@@ -66,7 +66,6 @@ Its many applications include:
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -51,7 +51,6 @@ Some of these extensions are presented as exercises.
 We'll need the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import random

--- a/lectures/lp_intro.md
+++ b/lectures/lp_intro.md
@@ -15,7 +15,7 @@ kernelspec:
 
 ## Overview
 
-**Linear programming** problems either maximize or minimize 
+**Linear programming** problems either maximize or minimize
 a linear objective function subject to a set of  linear equality and/or inequality constraints.
 
 Linear programs come in pairs:
@@ -23,7 +23,7 @@ Linear programs come in pairs:
 * an original  **primal** problem, and
 
 * an associated **dual** problem.
- 
+
 If a primal problem involves **maximization**, the dual problem involves **minimization**.
 
 If a primal problem involves  **minimization**, the dual problem involves **maximization**.
@@ -41,16 +41,15 @@ import numpy as np
 from scipy.optimize import linprog
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
-%matplotlib inline
 ```
 
 ## Objective Function and Constraints
 
 We want to minimize a **cost function** $c'x = \sum_{i=1}^n c_i x_i$ over  feasible values of $x = (x_1,x_2,\dots,x_n)'$.
 
-Here 
+Here
 
-*  $c = (c_1,c_2,\dots,c_n)'$ is  a **unit cost vector**,  and 
+*  $c = (c_1,c_2,\dots,c_n)'$ is  a **unit cost vector**,  and
 
 *  $x = (x_1,x_2,\dots,x_n)'$ is a vector of **decision variables**
 
@@ -58,9 +57,9 @@ Decision variables are  restricted to satisfy a set of linear equality and/or in
 
 We describe the constraints with the following  collections of  $n$-dimensional vectors $a_i$ and scalars $b_i$  and associated sets indexing the equality and inequality constraints:
 
-* $a_i$ for $i \in M_i$, where $M_1,M_2,M_3$ are each  sets of indexes 
- 
-and a collection of  scalers 
+* $a_i$ for $i \in M_i$, where $M_1,M_2,M_3$ are each  sets of indexes
+
+and a collection of  scalers
 
 * $b_i$ for $i \in N_i$, where $N_1,N_2,N_3$  are each sets of indexes.
 
@@ -80,21 +79,21 @@ $$ (linprog)
 
 A vector $x$ that satisfies all of the constraints is called a **feasible solution**.
 
-A collection of all feasible solutions is called  a **feasible set**. 
+A collection of all feasible solutions is called  a **feasible set**.
 
 A feasible solution $x$ that minimizes the cost function  is called an **optimal solution**.
 
-The corresponding value of cost function $c'x$ is called the  **optimal value**. 
+The corresponding value of cost function $c'x$ is called the  **optimal value**.
 
-If the feasible set is empty, we say that solving  the  linear programming problem is **infeasible**. 
+If the feasible set is empty, we say that solving  the  linear programming problem is **infeasible**.
 
 If, for any $K \in \mathbb R$, there exists a feasible solution $x$ such that $c'x < K$, we say that the problem is **unbounded** or equivalently that the optimal value is $-\infty$.
 
-## Example 1: Production Problem 
+## Example 1: Production Problem
 
 This example was created by {cite}`bertsimas_tsitsiklis1997`
 
-Suppose that a factory can produce two goods called Product $1$ and Product $2$. 
+Suppose that a factory can produce two goods called Product $1$ and Product $2$.
 
 To produce each product requires both material and labor.
 
@@ -113,7 +112,7 @@ Required per unit material and labor  inputs and  revenues  are shown in table b
 A firm's problem is to construct a  production plan that uses its  30 units of materials and 20 unites of labor
 to maximize its revenue.
 
-Let $x_i$ denote the quantity of Product $i$ that the firm produces. 
+Let $x_i$ denote the quantity of Product $i$ that the firm produces.
 
 This problem can be formulated as:
 
@@ -143,10 +142,10 @@ ax.text(-2, 2, "$x_2 \geq 0$", size=12)
 ax.text(2.5, -0.7, "$x_1 \geq 0$", size=12)
 
 # Draw the feasible region
-feasible_set = Polygon(np.array([[0, 0], 
-                                 [0, 6], 
-                                 [2.5, 5], 
-                                 [5, 0]]), 
+feasible_set = Polygon(np.array([[0, 0],
+                                 [0, 6],
+                                 [2.5, 5],
+                                 [5, 0]]),
                        color="cyan")
 ax.add_patch(feasible_set)
 
@@ -164,17 +163,17 @@ ax.text(2.7, 5.2, "Optimal Solution", size=12)
 plt.show()
 ```
 
-The blue region is the feasible set within which all constraints are satisfied. 
+The blue region is the feasible set within which all constraints are satisfied.
 
 Parallel orange lines are iso-revenue lines.
 
-The firm's objective is to find the  parallel orange lines to the upper boundary of the feasible set. 
+The firm's objective is to find the  parallel orange lines to the upper boundary of the feasible set.
 
-The intersection of the feasible set and the highest orange line delineates the optimal set. 
+The intersection of the feasible set and the highest orange line delineates the optimal set.
 
 In this example, the optimal set is the point $(2.5, 5)$.
 
-## Example 2: Investment Problem 
+## Example 2: Investment Problem
 
 We now consider a problem posed and solved by  {cite}`hu_guo2018`.
 
@@ -186,7 +185,7 @@ Three investment options are available:
 
 2. **Bank account:** the fund can deposit any amount  into a bank at the beginning of each year and receive its capital plus 6\% interest at the end of that year. In addition, the mutual fund is permitted to borrow no more than $20,000 at the beginning of each year and is asked to pay back the amount borrowed plus 6\% interest at the end of the year. The mutual fund can choose whether to deposit or borrow at the beginning of each year.
 
-3. **Corporate bond:** At the beginning of the second year, a  corporate bond becomes available. 
+3. **Corporate bond:** At the beginning of the second year, a  corporate bond becomes available.
 The fund can buy an amount
 that is no more than $ \$ $50,000 of this bond at the beginning of the second year and  at the end of the third year receive a payout of 130\% of the amount invested in the bond.
 
@@ -194,7 +193,7 @@ The mutual fund's objective is to maximize total payout that it owns at the end 
 
 We can formulate this  as a linear programming problem.
 
-Let  $x_1$ be the amount of put in the annuity, $x_2, x_3, x_4$ be  bank deposit balances at the beginning of the three years,  and $x_5$ be the amount invested  in the corporate bond. 
+Let  $x_1$ be the amount of put in the annuity, $x_2, x_3, x_4$ be  bank deposit balances at the beginning of the three years,  and $x_5$ be the amount invested  in the corporate bond.
 
 When $x_2, x_3, x_4$ are negative, it means that  the mutual fund has borrowed from  bank.
 
@@ -209,15 +208,15 @@ The table below shows the mutual fund's decision variables together with the tim
 The  mutual fund's decision making proceeds according to the following timing protocol:
 
 1. At the beginning of the first year, the mutual fund decides how much to invest in the annuity and
-   how much to deposit in the bank. This decision is subject to the constraint:  
+   how much to deposit in the bank. This decision is subject to the constraint:
 
    $$
    x_1 + x_2 = 100,000
-   $$ 
+   $$
 
 2. At the beginning of the second year, the mutual fund has a bank balance  of $1.06 x_2$.
    It must keep $x_1$ in the annuity. It can choose to put $x_5$ into the corporate bond,
-   and put $x_3$ in the bank. These decisions are restricted by 
+   and put $x_3$ in the bank. These decisions are restricted by
 
    $$
    x_1 + x_5 = 1.06 x_2 - x_3
@@ -256,12 +255,12 @@ $$
 
 ## Standard Form
 
-For purposes of 
+For purposes of
 
 * unifying linear programs that are initially stated in superficially different forms, and
 
 * having a form that is convenient to put into black-box software packages,
- 
+
 it is useful to devote some effort to describe a **standard form**.
 
 Our standard form  is:
@@ -277,14 +276,14 @@ $$
 \end{aligned}
 $$
 
-Let 
+Let
 
-$$ 
+$$
 A = \begin{bmatrix}
-a_{11} & a_{12} & \dots & a_{1n} \\ 
-a_{21} & a_{22} & \dots & a_{2n} \\ 
-  &   & \vdots &   \\ 
-a_{m1} & a_{m2} & \dots & a_{mn} \\ 
+a_{11} & a_{12} & \dots & a_{1n} \\
+a_{21} & a_{22} & \dots & a_{2n} \\
+  &   & \vdots &   \\
+a_{m1} & a_{m2} & \dots & a_{mn} \\
 \end{bmatrix}, \quad
 b = \begin{bmatrix} b_1 \\ b_2 \\ \vdots \\ b_m \\ \end{bmatrix}, \quad
 c = \begin{bmatrix} c_1 \\ c_2 \\ \vdots \\ c_n \\ \end{bmatrix}, \quad
@@ -301,7 +300,7 @@ $$
 \end{aligned}
 $$ (lpproblem)
 
-Here, $Ax = b$ means that  the $i$-th entry of $Ax$  equals the $i$-th entry of $b$ for every $i$. 
+Here, $Ax = b$ means that  the $i$-th entry of $Ax$  equals the $i$-th entry of $b$ for every $i$.
 
 Similarly, $x >= 0$ means that  $x_j$ is greater than $0$ for every $j$.
 
@@ -309,7 +308,7 @@ Similarly, $x >= 0$ means that  $x_j$ is greater than $0$ for every $j$.
 
 It is useful to know how to transform a problem that initially is not stated in the standard form into one that is.
 
-By deploying the following steps, any linear programming problem can be transformed into an  equivalent  standard form linear programming problem. 
+By deploying the following steps, any linear programming problem can be transformed into an  equivalent  standard form linear programming problem.
 
 1. **Objective Function:** If a problem is originally a constrained **maximization** problem, we can construct a new objective function that  is the additive inverse of the original objective function. The transformed problem is then a **minimization** problem.
 
@@ -430,13 +429,13 @@ res_ex1
 
 The optimal plan tells the  factory to produce 2.5 units of Product 1 and 5 units of  Product 2; that  generates a maximizing value of  revenue of 27.5.
 
-We are using the *linprog* function as a **black box**.  
+We are using the *linprog* function as a **black box**.
 
-Inside it, Python first  transforms the problem into  standard form. 
+Inside it, Python first  transforms the problem into  standard form.
 
 To do that, for each inequality constraint it generates one slack variable.
 
-Here the vector of slack variables is a two-dimensional NumPy array that  equals $b_{ub} - A_{ub}x$. 
+Here the vector of slack variables is a two-dimensional NumPy array that  equals $b_{ub} - A_{ub}x$.
 
 See the [official documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linprog.html#scipy.optimize.linprog) for more details.
 
@@ -527,10 +526,10 @@ In what  follows, we shall  use $a_i'$ to denote the $i$-th row of $A$ and $A_j$
 
 $$
 A = \begin{bmatrix}
-a_1' \\ 
-a_2' \\ 
-\ \\ 
-a_m' \\ 
+a_1' \\
+a_2' \\
+\ \\
+a_m' \\
 \end{bmatrix}.
 $$
 
@@ -542,11 +541,11 @@ To construct the  dual of linear programming problem {eq}`linprog`, we proceed a
 
 3. The dual problem is to **maximize**  objective function $b'p$.
 
-For a **maximization**  problem, we can first transform it to an equivalent minimization problem and then follow the above steps above to construct the  dual **minimization** problem. 
+For a **maximization**  problem, we can first transform it to an equivalent minimization problem and then follow the above steps above to construct the  dual **minimization** problem.
 
 We can easily verify that  **the dual of a dual problem is the  primal problem**.
 
-The following table summarizes relationships between objects in primal and dual problems. 
+The following table summarizes relationships between objects in primal and dual problems.
 
 |  Objective: Min  |  Objective: Max  |
 | :--------------: | :--------------: |
@@ -592,48 +591,48 @@ $$
 
 Primal and dual problems are linked by powerful **duality theorems** that have  **weak** and **strong** forms.
 
-The duality theorems provide the foundations of enlightening economic interpretations of linear programming problems. 
+The duality theorems provide the foundations of enlightening economic interpretations of linear programming problems.
 
 **Weak duality:** For linear programming problem {eq}`linprog`, if $x$ and $p$ are feasible solutions to the primal and the dual problems, respectively, then
 
-$$ 
-b'p \le c'x 
+$$
+b'p \le c'x
 $$
 
 **Strong duality:** For linear programming problem {eq}`linprog`, if the primal problem has an optimal solution $x$, then the dual problem also has an optimal solution. Denote an optimal solution of the dual problem as $p$. Then
 
-$$ 
-b'p = c'x 
+$$
+b'p = c'x
 $$
 
 According to strong duality, we can find the optimal value for the primal problem by solving the dual problem.
 
-But the dual problem tells us even more as we shall see next. 
+But the dual problem tells us even more as we shall see next.
 
 ### Complementary Slackness
 
-Let $x$ and $p$ be feasible solutions to the primal problem {eq}`linprog` and its dual problem, respectively. 
+Let $x$ and $p$ be feasible solutions to the primal problem {eq}`linprog` and its dual problem, respectively.
 
 Then $x$ and $p$ are also  optimal solutions of the primal and dual problems if and only if:
 
-$$ 
+$$
 p_i (a_i' x - b_i) = 0, \quad \forall i, \\
 x_j (A_j' p - c_j) = 0, \quad \forall j.
 $$
 
 This means that $p_i = 0$ if $a_i' x - b_i \neq 0$ and $x_j = 0$ if $A_j' p - c_j \neq 0$.
 
-These are the celebrated **complementary slackness** conditions. 
+These are the celebrated **complementary slackness** conditions.
 
 Let's interpret them.
 
-### Interpretations 
+### Interpretations
 
-Let's take a version of problem {eq}`linprog2` as a production problem and consider its associated dual problem.   
+Let's take a version of problem {eq}`linprog2` as a production problem and consider its associated dual problem.
 
 A factory produce $n$ products with $m$ types of resources.
 
-Where  $i=1,2,\dots,m$ and $j=1,2,\dots,n$, let 
+Where  $i=1,2,\dots,m$ and $j=1,2,\dots,n$, let
 
 * $x_j$ denote quantities of product $j$ to be produced
 
@@ -641,7 +640,7 @@ Where  $i=1,2,\dots,m$ and $j=1,2,\dots,n$, let
 
 * $b_i$ denotes the  avaliable amount of resource $i$
 
-* $c_j$ denotes the revenue generated by producing one unit of product $j$. 
+* $c_j$ denotes the revenue generated by producing one unit of product $j$.
 
 
 **Dual variables:** By  strong duality, we have
@@ -650,11 +649,11 @@ $$
 c_1 x_1 + c_2 x_2 + \dots + c_n x_n = b_1 p_1 + b_2 p_2 + \dots + b_m p_m.
 $$
 
-Evidently, a one unit change of $b_i$ results in $p_i$ units  change of revenue. 
+Evidently, a one unit change of $b_i$ results in $p_i$ units  change of revenue.
 
 Thus, a dual variable can be interpreted as the **value** of one unit of resource $i$.
 
-This is why it is often called the  **shadow price** of resource $i$. 
+This is why it is often called the  **shadow price** of resource $i$.
 
 For feasible but not optimal primal and dual solutions $x$ and $p$, by weak duality, we have
 
@@ -668,9 +667,9 @@ Here, the expression is opposite to the statement above since primal problem is 
 
 When a strict inequality holds, the solution is not optimal because  it doesn't fully utilize all valuable resources.
 
-Evidently, 
+Evidently,
 
-* if a shadow price $p_i$ is larger than the market price for Resource $i$, the factory should buy more Resource $i$ and expand its scale to generate more revenue; 
+* if a shadow price $p_i$ is larger than the market price for Resource $i$, the factory should buy more Resource $i$ and expand its scale to generate more revenue;
 
 * if a shadow price $p_i$ is less than the market price for Resource $i$, the factory should sell its  Resource $i$.
 
@@ -698,7 +697,7 @@ $$
 \end{aligned}
 $$
 
-We solve this dual problem by using the  function *linprog*. 
+We solve this dual problem by using the  function *linprog*.
 
 Since parameters used here are defined before when solving the primal problem, we won't define them here.
 
@@ -711,7 +710,7 @@ res_ex1_dual
 
 The optimal value for the dual problem equals  27.5.
 
-This equals the optimal value of  the primal problem, an illustration of  strong duality. 
+This equals the optimal value of  the primal problem, an illustration of  strong duality.
 
 Shadow prices for materials and labor are 0.625 and 0.4375, respectively.
 
@@ -760,7 +759,7 @@ bounds_ex2_dual = [(None, None),
                    (   0, None)]
 
 # Solve the dual problem
-res_ex2_dual = linprog(c_ex2_dual, A_eq=A_eq_ex2_dual, b_eq=b_eq_ex2_dual, 
+res_ex2_dual = linprog(c_ex2_dual, A_eq=A_eq_ex2_dual, b_eq=b_eq_ex2_dual,
                        A_ub=A_ub_ex2_dual, b_ub=b_ub_ex2_dual, bounds=bounds_ex2_dual)
 
 res_ex2_dual
@@ -776,9 +775,9 @@ $$
 100,000 p_1 - 20,000 p_4 - 20,000 p_5 - 20,000 p_6 + 50,000 p_7.
 $$
 
-We know if $b_i$ changes one dollor, then the optimal payoff in the end of the third year will change $p_i$ dollars. 
+We know if $b_i$ changes one dollor, then the optimal payoff in the end of the third year will change $p_i$ dollars.
 
-For $i = 1$, this means if the initial capital changes by one dollar, then the optimal payoff in the end of the third year will change $p_1$ dollars. 
+For $i = 1$, this means if the initial capital changes by one dollar, then the optimal payoff in the end of the third year will change $p_1$ dollars.
 
 Thus, $p_1$ is the potential value of one more unit of initial capital, or the shadow price for initial capital.
 
@@ -786,11 +785,11 @@ We can also interpret $p_1$ as the prospective  value in the end of the third ye
 
 If the mutual fund can raise money at a cost lower than $p_1 - 1$, then it should raise more money to increase its revenue.
 
-But if it bears a cost of funds higher than $p_1 - 1$, the mutual fund shouldn't do that. 
+But if it bears a cost of funds higher than $p_1 - 1$, the mutual fund shouldn't do that.
 
 For $i = 4, 5, 6$, this means that if the amount of capital that the fund is permitted to borrow from the bank changes by one dollar, the optimal pay out  at the end of the third year will change $p_i$ dollars.
 
-Thus, for $i = 4, 5, 6$, $|p_i|$ indicates the value of one dollar that the mutual fund can borrow from the bank at the beginning of the $i-3$-th year. 
+Thus, for $i = 4, 5, 6$, $|p_i|$ indicates the value of one dollar that the mutual fund can borrow from the bank at the beginning of the $i-3$-th year.
 
 $|p_i|$ is the shadow price for the loan amount. (We use absolute value here since $p_i \le 0$.)
 
@@ -798,7 +797,7 @@ If the interest rate is lower than $|p_i|$, then the mutual fund should borrow t
 
 For $i = 7$, this means that if the amount of the corporate bond the mutual fund can buy changes one dollar, then the optimal payoff will change $p_7$ dollars at the end of the third year.  Again, $p_7$ is the shadow price for the amount of the corporate bond the mutual fund can buy.
 
-As for numerical results 
+As for numerical results
 
 1. $p_1 = 1.38$, which means one dollar of initial capital is worth $\$ 1.38$ at the end of the third year.
 

--- a/lectures/lq_inventories.md
+++ b/lectures/lq_inventories.md
@@ -203,7 +203,6 @@ Here is code for computing an optimal decision rule and for analyzing
 its consequences.
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -70,7 +70,6 @@ In order to focus on computation, we leave longer proofs to these sources (while
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -72,7 +72,6 @@ Key tools for the lecture are
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/markov_perf.md
+++ b/lectures/markov_perf.md
@@ -58,7 +58,6 @@ Other references include chapter 7 of {cite}`Ljungqvist2012`.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -512,7 +511,7 @@ As expected, output is higher and prices are lower under duopoly than monopoly.
 
 ## Exercises
 
-```{exercise} 
+```{exercise}
 :label: mp_ex1
 
 Replicate the {ref}`pair of figures <mpe_vs_monopolist>` showing the comparison of output and prices for the monopolist and duopoly under MPE.

--- a/lectures/mccall_correlated.md
+++ b/lectures/mccall_correlated.md
@@ -47,7 +47,6 @@ This is to keep the model relatively simple as we study the impact of correlatio
 We will use the following imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/mccall_fitted_vfi.md
+++ b/lectures/mccall_fitted_vfi.md
@@ -57,7 +57,6 @@ Fitted VFI is very common in practice, so we will take some time to work through
 We will use the following imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/mccall_model.md
+++ b/lectures/mccall_model.md
@@ -60,7 +60,6 @@ As we'll see, McCall's model is not only interesting in its own right but also a
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -128,7 +127,7 @@ We'll go through these steps in turn.
 In order to optimally trade-off current and future rewards, we need to think about two things:
 
 1. the current payoffs we get from different choices
-1. the different states that those choices will lead to in next period 
+1. the different states that those choices will lead to in next period
 
 To weigh these two aspects of the decision problem, we need to assign *values*
 to states.
@@ -226,7 +225,7 @@ where
     \bar w := (1 - \beta) \left\{ c + \beta \sum_{w'} v^*(w') q (w') \right\}
 ```
 
-Here $\bar w$ (called the *reservation wage*) is a constant depending on 
+Here $\bar w$ (called the *reservation wage*) is a constant depending on
 $\beta, c$ and the wage distribution.
 
 The agent should accept if and only if the current wage offer exceeds the reservation wage.
@@ -239,15 +238,15 @@ In view of {eq}`reswage`, we can compute this reservation wage if we can compute
 To put the above ideas into action, we need to compute the value function at
 each possible state $w \in \mathbb W$.
 
-To simplify notation, let's set 
+To simplify notation, let's set
 
-$$  
+$$
 \mathbb W := \{w_1, \ldots, w_n  \}
     \quad \text{and} \quad
     v^*(i) := v^*(w_i)
 $$
 
-The value function is then represented by the vector 
+The value function is then represented by the vector
 $v^* = (v^*(i))_{i=1}^n$.
 
 In view of {eq}`odu_pv`, this vector satisfies the nonlinear system of equations

--- a/lectures/mccall_model_with_separation.md
+++ b/lectures/mccall_model_with_separation.md
@@ -55,7 +55,6 @@ worker preferences slightly more sophisticated.
 We'll need the following imports
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -576,4 +575,3 @@ plt.show()
 
 ```{solution-end}
 ```
-

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -12,11 +12,11 @@ kernelspec:
 ---
 
 (likelihood-ratio-process)=
-# Incorrect Models 
+# Incorrect Models
 
 ## Overview
 
-This  is a sequel to {doc}`this  quantecon lecture <likelihood_bayes>`.  
+This  is a sequel to {doc}`this  quantecon lecture <likelihood_bayes>`.
 
 We discuss  two ways to create compound lottery and their consequences.
 
@@ -39,9 +39,9 @@ That lecture studied an agent who knew both $f$ and $g$ but  did not know which 
 The agent represented that ignorance  by assuming that nature had chosen  $f$ or $g$ by  flipping an unfair coin that put probability  $\pi_{-1}$ on probability distribution $f$.
 
 That assumption allowed the agent to construct a subjective joint probability distribution over the
-random sequence $\{W_t\}_{t=0}^\infty$.  
+random sequence $\{W_t\}_{t=0}^\infty$.
 
-We studied how the agent would then use the laws of conditional probability and an observed   history $w^t =\{w_s\}_{t=0}^t$   to form   
+We studied how the agent would then use the laws of conditional probability and an observed   history $w^t =\{w_s\}_{t=0}^t$   to form
 
 $$
 \pi_t = E [ \textrm{nature chose distribution}  f | w^t] , \quad  t = 0, 1, 2, \ldots
@@ -54,11 +54,11 @@ The reason is that  now the wage sequence is actually described by a different s
 Thus, we change the {doc}`quantecon lecture <likelihood_bayes>` specification in the following way.
 
 Now, **each period** $t \geq 0$, nature flips a possibly unfair coin that comes up $f$ with probability $\alpha$
-and $g$ with probability $1 -\alpha$.  
+and $g$ with probability $1 -\alpha$.
 
-Thus, naturally perpetually draws from the **mixture distribution** with c.d.f. 
+Thus, naturally perpetually draws from the **mixture distribution** with c.d.f.
 
-$$ 
+$$
 H(w ) = \alpha F(w) + (1-\alpha) G(w), \quad \alpha \in (0,1)
 $$
 
@@ -77,7 +77,7 @@ Our first type of agent applies the learning algorithm described in {doc}`this  
 In the context of the statistical model that prevailed in that lecture, that was a good learning algorithm and it enabled the Bayesian learner
 eventually to learn the distribution that nature had drawn at time $-1$.
 
-This is because the agent's statistical model was *correct* in the sense of being aligned with the data 
+This is because the agent's statistical model was *correct* in the sense of being aligned with the data
 generating process.
 
 But in the present context, our type 1 decision maker's model is incorrect because the model $h$ that actually
@@ -94,17 +94,17 @@ We'll tell the sense in which it is closest.
 Our second type of agent understands that nature mixes between $f$ and $g$ each period with a fixed mixing
 probability $\alpha$.
 
-But  the agent doesn't know $\alpha$. 
+But  the agent doesn't know $\alpha$.
 
 The agent sets out to learn $\alpha$ using Bayes' law applied to his model.
 
 His model is correct in the sense that
 it includes the actual data generating process $h$ as a possible distribution.
 
-In this lecture, we'll learn about 
+In this lecture, we'll learn about
 
 * how nature can *mix* between two distributions $f$ and $g$ to create a new distribution $h$.
-   
+
 * The Kullback-Leibler statistical divergence <https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence> that governs statistical learning under an incorrect statistical model
 
 * A useful Python function `numpy.searchsorted` that,  in conjunction with a uniform random number generator, can be used to sample from an arbitrary distribution
@@ -114,7 +114,6 @@ As usual, we'll start by importing some Python tools.
 ```{code-cell} ipython3
 :hide-output: false
 
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -201,10 +200,10 @@ l_seq_f = np.cumprod(l_arr_f, axis=1)
 
 ## Sampling from  Compound Lottery $H$
 
-We implement two methods  to draw samples from 
-our mixture model $\alpha F + (1-\alpha) G$.  
+We implement two methods  to draw samples from
+our mixture model $\alpha F + (1-\alpha) G$.
 
-We'll generate samples using each of them and verify that they match well. 
+We'll generate samples using each of them and verify that they match well.
 
 Here is pseudo code for a direct "method 1" for drawing from our compound lottery:
 
@@ -212,11 +211,11 @@ Here is pseudo code for a direct "method 1" for drawing from our compound lotter
 
   * use the numpy.random.choice function to flip an unfair coin that selects distribution $F$ with prob $\alpha$
   and $G$ with prob $1 -\alpha$
-  
+
 * Step two:
-  
+
   * draw from either $F$ or $G$, as determined by the coin flip.
-  
+
 * Step three:
 
   * put the first two steps in a big loop and do them for each realization of $w$
@@ -230,13 +229,13 @@ In other words, if $X \sim F(x)$ we can generate a random sample from $F$ by dra
 a uniform distribution on $[0,1]$ and computing $F^{-1}(U)$.
 
 
-We'll  use this  fact 
+We'll  use this  fact
 in conjunction with the `numpy.searchsorted` command to sample from $H$ directly.
 
 See <https://numpy.org/doc/stable/reference/generated/numpy.searchsorted.html> for the
 `searchsorted` function.
 
-See the [Mr. P Solver video on Monte Carlo simulation](https://www.google.com/search?q=Mr.+P+Solver+video+on+Monte+Carlo+simulation&oq=Mr.+P+Solver+video+on+Monte+Carlo+simulation) to see other applications of this powerful trick. 
+See the [Mr. P Solver video on Monte Carlo simulation](https://www.google.com/search?q=Mr.+P+Solver+video+on+Monte+Carlo+simulation&oq=Mr.+P+Solver+video+on+Monte+Carlo+simulation) to see other applications of this powerful trick.
 
 In the Python code below, we'll use both of our methods and confirm that each of them does a good job of sampling
 from our target mixture distribution.
@@ -298,7 +297,7 @@ plt.show()
 
 **Note:** With numba acceleration the first method is actually only slightly slower than the second when we generated 1,000,000 samples.
 
-## Type 1 Agent 
+## Type 1 Agent
 
 We'll now study what our type 1 agent learns
 
@@ -403,7 +402,7 @@ the batch of data $ \left\{ w_{i}\right\} _{i=1}^{t+1} $.
 
 ## What a type 1 Agent Learns when Mixture $H$ Generates Data
 
-We now study what happens when the mixture distribution $h;\alpha$  truly generated the data each period.   
+We now study what happens when the mixture distribution $h;\alpha$  truly generated the data each period.
 
 A submartingale or supermartingale continues to describe $\pi_t$
 
@@ -430,13 +429,13 @@ def simulate_mixed(α, T=50, N=500):
 
 def plot_π_seq(α, π1=0.2, π2=0.8, T=200):
     """
-    Compute and plot π_seq and the log likelihood ratio process 
+    Compute and plot π_seq and the log likelihood ratio process
     when the mixed distribution governs the data.
     """
 
     l_arr_mixed = simulate_mixed(α, T=T, N=50)
     l_seq_mixed = np.cumprod(l_arr_mixed, axis=1)
-    
+
     T = l_arr_mixed.shape[1]
     π_seq_mixed = np.empty((2, T+1))
     π_seq_mixed[:, 0] = π1, π2
@@ -444,7 +443,7 @@ def plot_π_seq(α, π1=0.2, π2=0.8, T=200):
     for t in range(T):
         for i in range(2):
             π_seq_mixed[i, t+1] = update(π_seq_mixed[i, t], l_arr_mixed[0, t])
-    
+
     # plot
     fig, ax1 = plt.subplots()
     for i in range(2):
@@ -471,7 +470,7 @@ The above graph shows a sample path of the log likelihood ratio process as the b
 sample paths of $\pi_t$ that start from two distinct initial conditions.
 
 
-Let's see what happens when we change $\alpha$ 
+Let's see what happens when we change $\alpha$
 
 ```{code-cell} ipython3
 plot_π_seq(α = 0.2)
@@ -487,20 +486,20 @@ $$ h(w) \equiv h(w | \alpha) = \alpha f(w) + (1-\alpha) g(w) $$
 
 we shall compute the following two Kullback-Leibler divergences
 
-$$ 
-KL_g (\alpha) = \int \log\left(\frac{g(w)}{h(w)}\right) h(w) d w 
+$$
+KL_g (\alpha) = \int \log\left(\frac{g(w)}{h(w)}\right) h(w) d w
 $$
 
-and 
+and
 
-$$ 
-KL_f (\alpha) = \int \log\left(\frac{f(w)}{h(w)}\right) h(w) d w 
+$$
+KL_f (\alpha) = \int \log\left(\frac{f(w)}{h(w)}\right) h(w) d w
 $$
 
 We shall plot both of these functions against $\alpha$ as we use $\alpha$ to vary
 $h(w) = h(w|\alpha)$.
 
-The limit of $\pi_t$ is  determined by 
+The limit of $\pi_t$ is  determined by
 
 $$ \min_{f,g} \{KL_g, KL_f\} $$
 
@@ -513,11 +512,11 @@ As $\rightarrow +\infty$, $\pi_t$ goes to one if and only if  $KL_f < KL_g$
 def KL_g(α):
     "Compute the KL divergence between g and h."
     err = 1e-8                          # to avoid 0 at end points
-    ws = np.linspace(err, 1-err, 10000) 
+    ws = np.linspace(err, 1-err, 10000)
     gs, fs = g(ws), f(ws)
     hs = α*fs + (1-α)*gs
     return np.sum(np.log(gs/hs)*hs)/10000
-    
+
 @vectorize
 def KL_f(α):
     "Compute the KL divergence between f and h."
@@ -643,7 +642,7 @@ Our type 2 agent understands the correct statistical  model but acknowledges doe
 We apply Bayes law to deduce an algorithm for  learning $\alpha$ under the assumption
 that the agent knows that
 
-$$ 
+$$
 h(w) = h(w| \alpha)
 $$
 
@@ -658,17 +657,17 @@ We'll fire up `numpyro` and  apply it  to the present situation.
 Bayes' law now takes the form
 
 
-$$ 
-\pi_{t+1}(\alpha) = \frac {h(w_{t+1} | \alpha) \pi_t(\alpha)} 
-       { \int h(w_{t+1} | \hat \alpha) \pi_t(\hat \alpha) d \hat \alpha } 
+$$
+\pi_{t+1}(\alpha) = \frac {h(w_{t+1} | \alpha) \pi_t(\alpha)}
+       { \int h(w_{t+1} | \hat \alpha) \pi_t(\hat \alpha) d \hat \alpha }
 $$
 
 We'll use numpyro  to approximate this equation.
 
-We'll create  graphs of the posterior $\pi_t(\alpha)$ as 
+We'll create  graphs of the posterior $\pi_t(\alpha)$ as
 $t \rightarrow +\infty$ corresponding to ones presented in the quantecon lecture <https://python.quantecon.org/bayes_nonconj.html>.
 
-We anticipate that a posterior  distribution will collapse around  the true $\alpha$ as 
+We anticipate that a posterior  distribution will collapse around  the true $\alpha$ as
 $t \rightarrow + \infty$.
 
 Let us try a uniform prior first.
@@ -685,12 +684,12 @@ sizes = [5, 20, 50, 200, 1000, 25000]
 def model(w):
     α = numpyro.sample('α', dist.Uniform(low=0.0, high=1.0))
 
-    y_samp = numpyro.sample('w', 
+    y_samp = numpyro.sample('w',
         dist.Mixture(dist.Categorical(jnp.array([α, 1-α])), [dist.Beta(F_a, F_b), dist.Beta(G_a, G_b)]), obs=w)
 
 def MCMC_run(ws):
     "Compute posterior using MCMC with observed ws"
-    
+
     kernal = NUTS(model)
     mcmc = MCMC(kernal, num_samples=5000, num_warmup=1000, progress_bar=False)
 
@@ -708,20 +707,20 @@ fig, ax = plt.subplots(figsize=(10, 6))
 for i in range(len(sizes)):
     sample = MCMC_run(data[:sizes[i]])
     sns.histplot(
-        data=sample, kde=True, stat='density', alpha=0.2, ax=ax, 
+        data=sample, kde=True, stat='density', alpha=0.2, ax=ax,
         color=colors[i], binwidth=0.02, linewidth=0.05, label=f't={sizes[i]}'
     )
 ax.set_title('$\pi_t(\\alpha)$ as $t$ increases')
 ax.legend()
 ax.set_xlabel('$\\alpha$')
-plt.show() 
+plt.show()
 ```
 
-Evidently,  the Bayesian posterior  narrows in on the true value  $\alpha = .8$ of the mixing parameter as the length of a history of observations grows.  
+Evidently,  the Bayesian posterior  narrows in on the true value  $\alpha = .8$ of the mixing parameter as the length of a history of observations grows.
 
 ## Concluding Remarks
 
-Our type 1 person  deploys an incorrect statistical  model.  
+Our type 1 person  deploys an incorrect statistical  model.
 
 He believes
 that either $f$ or $g$ generated the $w$ process, but just doesn't know which one.
@@ -730,7 +729,7 @@ That is wrong because nature is actually mixing each period with mixing probabil
 
 Our type 1 agent  eventually believes that either $f$ or $g$ generated the $w$ sequence, the outcome being determined by the model, either $f$ or $g$, whose  KL divergence relative to $h$ is smaller.
 
-Our type 2 agent has a different statistical model, one that is correctly specified.  
+Our type 2 agent has a different statistical model, one that is correctly specified.
 
 He knows the parametric form of the statistical model but not the mixing parameter $\alpha$.
 

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -72,7 +72,7 @@ permanently draws from that distribution.
 Our second type of agent knows, correctly, that nature mixes $f$ and $g$ with mixing probability $\alpha \in (0,1)$
 each period, though the agent doesn't know the mixing parameter.
 
-Our first type of agent applies the learning algorithm described in {doc}`this  quantecon lecture <likelihood_bayes>`>.
+Our first type of agent applies the learning algorithm described in {doc}`this  quantecon lecture <likelihood_bayes>`.
 
 In the context of the statistical model that prevailed in that lecture, that was a good learning algorithm and it enabled the Bayesian learner
 eventually to learn the distribution that nature had drawn at time $-1$.

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -14,6 +14,14 @@ kernelspec:
 (likelihood-ratio-process)=
 # Incorrect Models
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+```{code-cell} ipython
+---
+tags: [hide-output]
+---
+!pip install numpyro jax
+```
+
 ## Overview
 
 This  is a sequel to {doc}`this  quantecon lecture <likelihood_bayes>`.

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -43,7 +43,6 @@ economic factors such as market size and tax rate predict.
 We'll require the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/multi_hyper.md
+++ b/lectures/multi_hyper.md
@@ -111,7 +111,6 @@ The right tool for the administrator's job is the **multivariate hypergeometric 
 Let's start with some imports.
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -61,7 +61,6 @@ We apply our Python class to some examples.
 We  use the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -115,7 +114,7 @@ def f(z, μ, Σ):
 For some integer $k\in \{1,\dots, N-1\}$, partition
 $z$ as
 
-$$ 
+$$
 z=\left[\begin{array}{c} z_{1}\\ z_{2} \end{array}\right],
 $$
 
@@ -301,32 +300,32 @@ We have computed everything we need to compute two regression lines, one of $z_2
 We'll represent  these regressions as
 
 $$
-z_1 = a_1 + b_1 z_2 + \epsilon_1 
+z_1 = a_1 + b_1 z_2 + \epsilon_1
 $$
 
 and
 
-$$ 
+$$
 z_2 = a_2 + b_2 z_1 + \epsilon_2
 $$
 
 where we have the population least squares orthogonality conditions
 
 $$
-E \epsilon_1 z_2 = 0 
+E \epsilon_1 z_2 = 0
 $$
 
-and 
+and
 
-$$ 
-E \epsilon_2 z_1 = 0 
+$$
+E \epsilon_2 z_1 = 0
 $$
 
 Let's  compute $a_1, a_2, b_1, b_2$.
 
 ```{code-cell} python3
 
-beta = multi_normal.βs 
+beta = multi_normal.βs
 
 a1 = μ[0] - beta[0]*μ[1]
 b1 = beta[0]
@@ -401,7 +400,7 @@ print("a1 = ", a1)
 print("b1 = ", b1)
 ```
 
-The blue line is the expectation of $z_2$ conditional on $z_1$.  
+The blue line is the expectation of $z_2$ conditional on $z_1$.
 
 The intercept and slope of the blue line are
 
@@ -692,7 +691,7 @@ We can now use our `MultivariateNormal` class to construct an
 instance, then partition the mean vector and covariance matrix as we
 wish.
 
-We want to regress IQ, the random variable $\theta$ (_what we don't know_), on the vector $y$  of test scores (_what we do know_). 
+We want to regress IQ, the random variable $\theta$ (_what we don't know_), on the vector $y$  of test scores (_what we do know_).
 
 We choose `k=n` so that $z_{1} = y$ and $z_{2} = \theta$.
 
@@ -1702,11 +1701,11 @@ where $v_0$ is orthogonal to $x_0$, $G$ is a
 $p \times n$ matrix, and $R$ is a $p \times p$
 positive definite matrix.
 
-We consider the problem of someone who 
+We consider the problem of someone who
 
 * *observes* $y_0$
 *  does not observe $x_0$,
-*  knows $\hat x_0, \Sigma_0, G, R$ and therefore  the joint probability distribution of the vector $\begin{bmatrix} x_0 \cr y_0 \end{bmatrix}$ 
+*  knows $\hat x_0, \Sigma_0, G, R$ and therefore  the joint probability distribution of the vector $\begin{bmatrix} x_0 \cr y_0 \end{bmatrix}$
 * wants to infer $x_0$ from $y_0$ in light of what he knows about that
 joint probability distribution.
 
@@ -1740,7 +1739,7 @@ $x_0$ conditional on $y_0$ is ${\mathcal N}(\tilde x_0, \tilde \Sigma_0)$ by rep
 as
 
 $$
- x_0 = \tilde x_0 + \zeta_0 
+ x_0 = \tilde x_0 + \zeta_0
 $$ (eq:x0rep2)
 
 where $\zeta_0$ is a Gaussian random vector that is orthogonal to $\tilde x_0$ and $y_0$ and that
@@ -1760,13 +1759,13 @@ $$
 where $A$ is an $n \times n$ matrix and $C$ is an
 $n \times m$ matrix.
 
-Using equation {eq}`eq:x0rep2`, we can also represent $x_1$ as 
+Using equation {eq}`eq:x0rep2`, we can also represent $x_1$ as
 
 $$
-x_1 = A (\tilde x_0 + \zeta_0) + C w_1 
+x_1 = A (\tilde x_0 + \zeta_0) + C w_1
 $$
 
-It follows that 
+It follows that
 
 $$ E x_1 | y_0 = A \tilde x_0
 $$
@@ -1775,10 +1774,10 @@ $$
 and that the corresponding conditional covariance matrix $E (x_1 - E x_1| y_0)  (x_1 - E x_1| y_0)' \equiv \Sigma_1$ is
 
 $$
- \Sigma_1 = A \tilde \Sigma_0 A' + C C' 
+ \Sigma_1 = A \tilde \Sigma_0 A' + C C'
 $$
 
-or 
+or
 
 $$
 \Sigma_1 =  A \Sigma_0 A' - A \Sigma_0 G' (G \Sigma_0 G' + R)^{-1} G \Sigma_0 A'
@@ -1787,18 +1786,18 @@ $$
 We can write the mean of $x_1$ conditional on $y_0$ as
 
 $$
- \hat x_1 = A \hat x_0 + A \Sigma_0 G' (G \Sigma_0 G' + R)^{-1} (y_0 - G \hat x_0) 
+ \hat x_1 = A \hat x_0 + A \Sigma_0 G' (G \Sigma_0 G' + R)^{-1} (y_0 - G \hat x_0)
 $$
 
-or 
+or
 
 $$
- \hat x_1 = A \hat x_0 + K_0 (y_0 - G \hat x_0) 
+ \hat x_1 = A \hat x_0 + K_0 (y_0 - G \hat x_0)
 $$
 
-where 
+where
 
-$$ 
+$$
 K_0 = A \Sigma_0 G' (G \Sigma_0 G' + R)^{-1}
 $$
 
@@ -1850,20 +1849,20 @@ If we shift the first equation forward one period and then substitute the expres
 into it we obtain
 
 $$
-\Sigma_{t+1}= C C' + A \Sigma_t A' - A \Sigma_t G' (G \Sigma_t G' +R)^{-1} G \Sigma_t A' . 
+\Sigma_{t+1}= C C' + A \Sigma_t A' - A \Sigma_t G' (G \Sigma_t G' +R)^{-1} G \Sigma_t A' .
 $$
 
 This is a matrix Riccati difference equation that is closely related to another matrix Riccati difference equation that appears in  a quantecon lecture on the basics of linear quadratic control theory.
 
-That equation has the form  
+That equation has the form
 
-  
+
 
 ```{math}
 
-P_{t-1} =R + A' P_t A  - A' P_t B 
+P_{t-1} =R + A' P_t A  - A' P_t B
 (B' P_t B + Q)^{-1}  B' P_t A  .
- 
+
 ```
 
 Stare at the two preceding equations for a moment or two, the first being a matrix difference equation for a conditional covariance matrix, the
@@ -1873,7 +1872,7 @@ Although the  two equations are not identical, they display striking family rese
 
 * the first equation tells dynamics that work **forward**  in time
 * the second equation tells dynamics that work  **backward** in time
-* while many of the terms are similar, one equation seems to apply matrix transformations to some matrices that play similar roles in the other equation 
+* while many of the terms are similar, one equation seems to apply matrix transformations to some matrices that play similar roles in the other equation
 
 The family resemblences of these two equations reflects a transcendent **duality** between control theory and filtering theory.
 
@@ -2054,7 +2053,7 @@ $$
 
 where the first half of the first column of $\Lambda$ is filled
 with $1$s and $0$s for the rest half, and symmetrically
-for the second column. 
+for the second column.
 
 $D$ is a diagonal matrix with parameter
 $\sigma_{u}^{2}$ on the diagonal.
@@ -2295,4 +2294,3 @@ Pjk = P[:, :2]
 Σy_hat = Pjk @ Σεjk @ Pjk.T
 print('Σy_hat = \n', Σy_hat)
 ```
-

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -30,7 +30,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!pip install quantecon interpolation
+!pip install interpolation
 ```
 
 ```{code-cell} ipython

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -34,7 +34,6 @@ tags: [hide-output]
 ```
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -30,8 +30,7 @@ In addition to what’s in Anaconda, this lecture deploys the libraries:
 ---
 tags: [hide-output]
 ---
-  !pip install quantecon
-  !pip install interpolation
+!pip install interpolation
 ```
 
 ## Overview

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -58,7 +58,6 @@ must be learned.
 Let’s start with some imports
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from numba import njit, prange, vectorize

--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -58,7 +58,6 @@ Such variation is needed to determine whether it is institutions that give rise 
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/optgrowth.md
+++ b/lectures/optgrowth.md
@@ -60,7 +60,6 @@ techniques to drastically improve execution time over the next few lectures.
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/optgrowth_fast.md
+++ b/lectures/optgrowth_fast.md
@@ -60,7 +60,6 @@ accelerate our code.
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -361,7 +361,6 @@ Using this series, we can plot the average real minimum wage over the
 past decade for each country in our data set
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import matplotlib

--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -27,15 +27,6 @@ kernelspec:
 :depth: 2
 ```
 
-In addition to what's in Anaconda, this lecture will need the following libraries:
-
-```{code-cell} ipython
----
-tags: [hide-output]
----
-!pip install quantecon
-```
-
 ## Overview
 
 This lecture describes a rational expectations version of the famous permanent income model of Milton Friedman {cite}`Friedman1956`.

--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -56,7 +56,6 @@ Background readings on the linear-quadratic-Gaussian permanent income model are 
 Let's start with some imports
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -1008,4 +1007,3 @@ The proof for the general case is similar.
 [^f5]: A moving average representation for a process $y_t$ is said to be **fundamental** if the linear space spanned by $y^t$ is equal to the linear space spanned by $w^t$.  A time-invariant innovations representation, attained via the Kalman filter, is by construction fundamental.
 
 [^f8]: See {cite}`CampbellShiller88`, {cite}`LettLud2001`, {cite}`LettLud2004` for interesting applications of related ideas.
-

--- a/lectures/perm_income_cons.md
+++ b/lectures/perm_income_cons.md
@@ -75,7 +75,6 @@ The model will prove useful for illustrating concepts such as
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import quantecon as qe
@@ -790,4 +789,3 @@ Let's have a look at the cointegration figure
 cointegration_figure(bsimb, csimb)
 plt.show()
 ```
-

--- a/lectures/prob_matrix.md
+++ b/lectures/prob_matrix.md
@@ -19,18 +19,18 @@ After providing somewhat informal definitions of the underlying objects, we'll u
 
 Among concepts that we'll be studying include
 
-- a joint probability distribution 
+- a joint probability distribution
 - marginal distributions associated with a given joint distribution
 - conditional probability distributions
 - statistical independence of two random variables
 - joint distributions associated with a prescribed set of marginal distributions
     - couplings
     - copulas
-- the probability distribution of a sum of two independent random variables 
+- the probability distribution of a sum of two independent random variables
     - convolution of  marginal distributions
 - parameters that define a probability distribution
 - sufficient statistics as data summaries
-  
+
 We'll use a matrix to represent a bivariate probability distribution and a vector to represent a univariate probability distribution
 
 
@@ -47,23 +47,22 @@ import prettytable as pt
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib_inline.backend_inline import set_matplotlib_formats
 set_matplotlib_formats('retina')
-%matplotlib inline
 ```
 
 
 ## Sketch of Basic Concepts
 
-We'll briefly define what we mean by a **probability space**, a **probability measure**, and a **random variable**. 
+We'll briefly define what we mean by a **probability space**, a **probability measure**, and a **random variable**.
 
 For most of this lecture, we sweep these objects into the background, but they are there underlying the other objects that we'll mainly focus on.
 
 Let $\Omega$ be a set of possible underlying outcomes and let $\omega \in \Omega$ be a particular underlying outcomes.
 
-Let $\mathcal{G} \subset \Omega$ be a subset of $\Omega$. 
+Let $\mathcal{G} \subset \Omega$ be a subset of $\Omega$.
 
-Let $\mathcal{F}$ be a collection of such subsets  $\mathcal{G} \subset \Omega$. 
+Let $\mathcal{F}$ be a collection of such subsets  $\mathcal{G} \subset \Omega$.
 
-The pair $\Omega,\mathcal{F}$  forms our **probability space** on which we want to put a probability measure. 
+The pair $\Omega,\mathcal{F}$  forms our **probability space** on which we want to put a probability measure.
 
 A **probability measure** $\mu$ maps a set of possible underlying outcomes  $\mathcal{G} \in \mathcal{F}$  into a scalar number between $0$ and $1$
 
@@ -75,8 +74,8 @@ A **random variable** $X(\omega)$ is a function of the underlying outcome $\omeg
 The random variable $X(\omega)$  has a **probability distribution** that is induced by the underlying probability measure $\mu$ and the function
 $X(\omega)$:
 
-$$ 
-\textrm{Prob} (X \in A ) = \int_{\mathcal{G}} \mu(\omega) d \omega 
+$$
+\textrm{Prob} (X \in A ) = \int_{\mathcal{G}} \mu(\omega) d \omega
 $$ (eq:CDFfromdensity)
 
 where ${\mathcal G}$ is the subset of $\Omega$ for which $X(\omega) \in A$.
@@ -84,13 +83,13 @@ where ${\mathcal G}$ is the subset of $\Omega$ for which $X(\omega) \in A$.
 We call this the induced probability distribution of random variable $X$.
 
 
-## What Does Probability Mean? 
+## What Does Probability Mean?
 
 Before diving in, we'll say a few words about what probability theory means and how it connects to statistics.
 
 We  also touch  on these topics in the quantecon lectures  <https://python.quantecon.org/prob_meaning.html> and <https://python.quantecon.org/navy_captain.html>.
 
-For much of this lecture we'll be discussing  fixed "population" probabilities. 
+For much of this lecture we'll be discussing  fixed "population" probabilities.
 
 These are purely mathematical objects.
 
@@ -100,9 +99,9 @@ To appreciate how statisticians connect probabilities to data, the key is to und
 * Repeated independently  and identically distributed (i.i.d.)  draws of "samples" or "realizations" from the same probability distribution
 * A **statistic** defined as a  function of a sequence of samples
 * An **empirical distribution** or **histogram** (a binned empirical distribution) that records observed  **relative frequencies**
-* The idea that a  population probability  distribution is  what we anticipate **relative frequencies** will be in a long sequence of i.i.d. draws. Here the following mathematical machinery makes precise what is meant by **anticipated relative frequencies** 
+* The idea that a  population probability  distribution is  what we anticipate **relative frequencies** will be in a long sequence of i.i.d. draws. Here the following mathematical machinery makes precise what is meant by **anticipated relative frequencies**
      - **Law of Large Numbers (LLN)**
-     -  **Central Limit Theorem (CLT)** 
+     -  **Central Limit Theorem (CLT)**
 
 
 **Scalar example**
@@ -110,7 +109,7 @@ To appreciate how statisticians connect probabilities to data, the key is to und
 
 Consider the following discrete distribution
 
-$$ 
+$$
 X  \sim \{{f_i}\}_{i=0}^{I-1},\quad f_i \geqslant 0, \quad \sum_i f_i = 1
 $$
 
@@ -136,24 +135,24 @@ i & = 0,\dots,I-1,\\
 N_i & = \text{number of times} \ X = i,\\
 N & = \sum^{I-1}_{i=0} N_i \quad \text{total number of draws},\\
 \tilde {f_i} &  = \frac{N_i}{N} \sim \ \text{frequency of draws for which}\  X=i
-\end{aligned} 
+\end{aligned}
 $$
 
 
 Key ideas that  justify connecting probability theory with statistics are laws of large numbers and central limit theorems
 
-**LLN:** 
+**LLN:**
 
 - A Law of Large Numbers (LLN) states that $\tilde {f_i} \to f_i \text{ as } N \to \infty$
 
-**CLT:** 
+**CLT:**
 
 - A Central Limit Theorem (CLT) describes a  **rate** at which $\tilde {f_i} \to f_i$
 
 
-**Remarks** 
+**Remarks**
 
-- For "frequentist" statisticians, **anticipated relative frequency**  is **all** that a probability distribution means. 
+- For "frequentist" statisticians, **anticipated relative frequency**  is **all** that a probability distribution means.
 
 - But for a Bayesian it means something more or different.
 
@@ -163,13 +162,13 @@ Key ideas that  justify connecting probability theory with statistics are laws o
 A  probability distribution $\textrm{Prob} (X \in A)$ can  be described by its **cumulative distribution function (CDF)**
 
 $$
-F_{X}(x) = \textrm{Prob}\{X\leq x\}. 
+F_{X}(x) = \textrm{Prob}\{X\leq x\}.
 $$
 
-Sometimes, but not always, a random variable can also be described by  **density function** $f(x)$ 
+Sometimes, but not always, a random variable can also be described by  **density function** $f(x)$
 that is related to its CDF by
 
-$$ 
+$$
 \textrm{Prob} \{X\in B\} = \int_{t\in B}f(t)dt
 $$
 
@@ -181,14 +180,14 @@ Here $B$ is a set of possible $X$'s whose probability we want to compute.
 
 When a probability density exists, a probability distribution can be characterized either by its CDF or by its  density.
 
-For a **discrete-valued** random variable  
+For a **discrete-valued** random variable
 
-* the number  of possible values of $X$ is finite or countably infinite 
-* we replace a  **density** with a **probability mass function**, a non-negative sequence that sums to one 
-* we replace integration with summation in the formula like {eq}`eq:CDFfromdensity` that relates a CDF to a probability mass function 
+* the number  of possible values of $X$ is finite or countably infinite
+* we replace a  **density** with a **probability mass function**, a non-negative sequence that sums to one
+* we replace integration with summation in the formula like {eq}`eq:CDFfromdensity` that relates a CDF to a probability mass function
 
 
-In this lecture, we mostly discuss discrete random variables.  
+In this lecture, we mostly discuss discrete random variables.
 
 Doing this enables us to confine our tool set basically to linear algebra.
 
@@ -203,14 +202,14 @@ about continuous-valued random variables.
 
 ### Discrete random variable
 
-Let $X$ be a discrete random variable that takes possible values: $i=0,1,\ldots,I-1 = \bar{X}$. 
+Let $X$ be a discrete random variable that takes possible values: $i=0,1,\ldots,I-1 = \bar{X}$.
 
 Here, we choose  the maximum index $I-1$ because of how this aligns nicely with Python's index convention.
 
 Define $f_i \equiv \textrm{Prob}\{X=i\}$
-and assemble  the non-negative vector 
+and assemble  the non-negative vector
 
-$$ 
+$$
 f=\left[\begin{array}{c}
 f_{0}\\
 f_{1}\\
@@ -219,7 +218,7 @@ f_{I-1}
 \end{array}\right]
 $$ (eq:discretedist)
 
-for which  $f_{i} \in [0,1]$ for each $i$ and $\sum_{i=0}^{I-1}f_i=1$. 
+for which  $f_{i} \in [0,1]$ for each $i$ and $\sum_{i=0}^{I-1}f_i=1$.
 
 This vector defines a **probability mass function**.
 
@@ -234,11 +233,11 @@ These parameters pin down the shape of the distribution.
 Such a "non-parametric" distribution has as many "parameters" as there are possible values of the random variable.
 
 
-We often work with special  distributions that  are  characterized by  a small number  parameters. 
+We often work with special  distributions that  are  characterized by  a small number  parameters.
 
-In these special parametric  distributions, 
+In these special parametric  distributions,
 
-$$ 
+$$
 f_i = g(i; \theta)
 $$
 
@@ -249,25 +248,25 @@ where $\theta $ is a vector of parameters that is of much smaller dimension than
 
 - The concept of  **parameter** is intimately related to the notion of  **sufficient statistic**.
 -  Sufficient statistics are  nonlinear functions of a data set.
--  Sufficient statistics are designed to  summarize all  **information** about  parameters that is contained in a data set. 
+-  Sufficient statistics are designed to  summarize all  **information** about  parameters that is contained in a data set.
 -  They are important tools that AI uses to summarize  a **big data** set
 -  R. A. Fisher provided a rigorous definition of **information** -- see <https://en.wikipedia.org/wiki/Fisher_information>
 
 
- 
+
 An example of a parametric probability distribution is  a **geometric distribution**.
 
 It is described by
 
-$$ 
+$$
 f_{i} = \textrm{Prob}\{X=i\} = (1-\lambda)\lambda^{i},\quad \lambda \in [0,1], \quad i = 0, 1, 2, \ldots
-$$ 
+$$
 
 Evidently,  $\sum_{i=0}^{\infty}f_i=1$.
 
 Let $\theta$ be a vector of parameters of the distribution described by $f$, then
 
-$$ 
+$$
 f_i( \theta)\ge0, \sum_{i=0}^{\infty}f_i(\theta)=1
 $$
 
@@ -278,11 +277,11 @@ Let $X$ be a continous random variable that takes values $X \in \tilde{X}\equiv[
 $$
 \textrm{Prob}\{X\in A\} = \int_{x\in A} f(x;\theta)\,dx;  \quad f(x;\theta)\ge0
 $$
-  
-where $A$ is a subset of $\tilde{X}$ and 
-  
-$$ 
-\textrm{Prob}\{X\in \tilde{X}\} =1 
+
+where $A$ is a subset of $\tilde{X}$ and
+
+$$
+\textrm{Prob}\{X\in \tilde{X}\} =1
 $$
 
 ## Bivariate Probability Distributions
@@ -294,14 +293,14 @@ To begin, we restrict ourselves to two discrete random variables.
 Let $X,Y$ be two discrete random variables that take values:
 
 $$
-X\in\{0,\ldots,I-1\} 
+X\in\{0,\ldots,I-1\}
 $$
 
 $$
 Y\in\{0,\ldots,J-1\}
 $$
 
-Then their **joint distribution** is described by a matrix 
+Then their **joint distribution** is described by a matrix
 
 $$
 F_{I\times J}=[f_{ij}]_{i\in\{0,\ldots,I-1\}, j\in\{0,\ldots,J-1\}}
@@ -313,7 +312,7 @@ $$
 f_{ij}=\textrm{Prob}\{X=i,Y=j\} \geq 0
 $$
 
-where 
+where
 
 $$
 \sum_{i}\sum_{j}f_{ij}=1
@@ -321,17 +320,17 @@ $$
 
 ## Marginal Probability Distributions
 
-The joint distribution induce marginal distributions 
+The joint distribution induce marginal distributions
 
 $$
 \textrm{Prob}\{X=i\}= \sum_{j=0}^{J-1}f_{ij} = \mu_i, \quad i=0,\ldots,I-1
 $$
 
 $$
-\textrm{Prob}\{Y=j\}= \sum_{i=0}^{I-1}f_{ij} = \nu_j, \quad j=0,\ldots,J-1 
+\textrm{Prob}\{Y=j\}= \sum_{i=0}^{I-1}f_{ij} = \nu_j, \quad j=0,\ldots,J-1
 $$
 
-For example, let a joint distribution over $(X,Y)$ be 
+For example, let a joint distribution over $(X,Y)$ be
 
 $$
 F = \left[
@@ -344,8 +343,8 @@ $$ (eq:example101discrete)
 
 The implied  marginal distributions are:
 
-$$ 
-\begin{aligned} 
+$$
+\begin{aligned}
 \textrm{Prob} \{X=0\}&=.25+.1=.35\\
 \textrm{Prob}\{X=1\}& =.15+.5=.65\\
 \textrm{Prob}\{Y=0\}&=.25+.15=.4\\
@@ -353,7 +352,7 @@ $$
 \end{aligned}
 $$
 
-**Digression:** If two random variables $X,Y$ are continuous and have joint density $f(x,y)$, then marginal distributions can be computed by 
+**Digression:** If two random variables $X,Y$ are continuous and have joint density $f(x,y)$, then marginal distributions can be computed by
 
 $$
 \begin{aligned}
@@ -370,18 +369,18 @@ $$
 \textrm{Prob}\{A \mid B\}=\frac{\textrm{Prob}\{A \cap B\}}{\textrm{Prob}\{B\}}
 $$
 
-where $A, B$ are two events. 
+where $A, B$ are two events.
 
-For a pair of discrete random variables, we have  the **conditional distribution** 
+For a pair of discrete random variables, we have  the **conditional distribution**
 
 $$
-\textrm{Prob}\{X=i|Y=j\}=\frac{f_{ij}}{\sum_{i}f_{ij}} 
+\textrm{Prob}\{X=i|Y=j\}=\frac{f_{ij}}{\sum_{i}f_{ij}}
 =\frac{\textrm{Prob} \{X=i, Y=j\} }{\textrm{Prob} \{Y=j\} }
 $$
 
 where $i=0, \ldots,I-1, \quad j=0,\ldots,J-1$.
 
-Note that   
+Note that
 
 $$
 \sum_{i}\textrm{Prob}\{X_i=i|Y_j=j\}
@@ -402,22 +401,22 @@ $$
 
 ## Statistical Independence
 
-Random variables X and Y are statistically **independent** if 
+Random variables X and Y are statistically **independent** if
 
-$$ 
+$$
 \textrm{Prob}\{X=i,Y=j\}={f_ig_j}
 $$
 
-where 
+where
 
-$$ 
+$$
 \begin{aligned}
 \textrm{Prob}\{X=i\} &=f_i\ge0， \sum{f_i}=1 \cr
 \textrm{Prob}\{Y=j\} & =g_j\ge0， \sum{g_j}=1
 \end{aligned}
 $$
 
-Conditional distributions are 
+Conditional distributions are
 
 $$
 \begin{aligned}
@@ -433,13 +432,13 @@ The  mean and variance of a discrete random variable $X$  are
 
 $$
 \begin{aligned}
-\mu_{X} & \equiv\mathbb{E}\left[X\right] 
-=\sum_{k}k \textrm{Prob}\{X=k\} \\ 
+\mu_{X} & \equiv\mathbb{E}\left[X\right]
+=\sum_{k}k \textrm{Prob}\{X=k\} \\
 \sigma_{X}^{2} & \equiv\mathbb{D}\left[X\right]=\sum_{k}\left(k-\mathbb{E}\left[X\right]\right)^{2}\textrm{Prob}\{X=k\}
-\end{aligned} 
+\end{aligned}
 $$
 
-A continuous random variable having  density $f_{X}(x)$) has  mean and variance 
+A continuous random variable having  density $f_{X}(x)$) has  mean and variance
 
 $$
 \begin{aligned}
@@ -460,7 +459,7 @@ $$
 How can we transform $\tilde{X}$ to get a random variable $X$ for which $\textrm{Prob}\{X=i\}=f_i,\quad i=0,\ldots,I-1$,
  where $f_i$ is an arbitary discrete probability distribution on $i=0,1,\dots,I-1$?
 
-The key tool is the inverse of a cumulative distribution function (CDF). 
+The key tool is the inverse of a cumulative distribution function (CDF).
 
 Observe that the CDF of a distribution is monotone and non-decreasing, taking values between $0$ and $1$.
 
@@ -477,20 +476,20 @@ Thus, knowing the **"inverse"** CDF of a distribution is enough to simulate from
 The "inverse" CDF needs to exist for this method to work.
 ```
 
-The inverse CDF is 
+The inverse CDF is
 
 $$
 F^{-1}(u)\equiv\inf \{x\in \mathbb{R}: F(x) \geq u\} \quad(0<u<1)
 $$
 
-Here  we use infimum because a CDF is a non-decreasing and right-continuous function. 
+Here  we use infimum because a CDF is a non-decreasing and right-continuous function.
 
-Thus, suppose that 
+Thus, suppose that
 
--  $U$ is a uniform random variable $U\in[0,1]$ 
+-  $U$ is a uniform random variable $U\in[0,1]$
 -  We want to sample a random variable $X$ whose  CDF is  $F$.
 
-It turns out that if we use draw uniform random numbers $U$ and then compute  $X$ from 
+It turns out that if we use draw uniform random numbers $U$ and then compute  $X$ from
 
 $$
 X=F^{-1}(U),
@@ -498,17 +497,17 @@ $$
 
 then $X$ ia a random variable  with CDF $F_X(x)=F(x)=\textrm{Prob}\{X\le x\}$.
 
-We'll verify this in  the special case in which  $F$ is continuous and bijective so that its inverse function exists and  
+We'll verify this in  the special case in which  $F$ is continuous and bijective so that its inverse function exists and
 can be  denoted by $F^{-1}$.
 
-Note that 
+Note that
 
 $$
 \begin{aligned}
 F_{X}\left(x\right)	& =\textrm{Prob}\left\{ X\leq x\right\} \\
 	& =\textrm{Prob}\left\{ F^{-1}\left(U\right)\leq x\right\} \\
 	& =\textrm{Prob}\left\{ U\leq F\left(x\right)\right\} \\
-	& =F\left(x\right) 
+	& =F\left(x\right)
 \end{aligned}
 $$
 
@@ -520,25 +519,25 @@ Let's use  `numpy` to compute some examples.
 
 Let $X$ follow a geometric distribution, with parameter $\lambda>0$.
 
-Its density function is 
+Its density function is
 
 $$
 \quad f(x)=\lambda e^{-\lambda x}
 $$
 
-Its CDF is 
+Its CDF is
 
 $$
 F(x)=\int_{0}^{\infty}\lambda e^{-\lambda x}=1-e^{-\lambda x}
 $$
 
-Let $U$ follow a uniform distribution on $[0,1]$. 
+Let $U$ follow a uniform distribution on $[0,1]$.
 
-$X$ is a random variable such that $U=F(X)$. 
+$X$ is a random variable such that $U=F(X)$.
 
-The distribution $X$ can be deduced from 
+The distribution $X$ can be deduced from
 
-$$ 
+$$
 \begin{aligned}
 U& =F(X)=1-e^{-\lambda X}\qquad\\
 \implies & \quad -U=e^{-\lambda X}\\
@@ -581,7 +580,7 @@ plt.show()
 Let $X$ distributed geometrically, that is
 
 $$
-\begin{aligned} 
+\begin{aligned}
 \textrm{Prob}(X=i) & =(1-\lambda)\lambda^i,\quad\lambda\in(0,1), \quad  i=0,1,\dots \\
  & \sum_{i=0}^{\infty}\textrm{Prob}(X=i)=1\longleftrightarrow(1- \lambda)\sum_{i=0}^{\infty}\lambda^i=\frac{1-\lambda}{1-\lambda}=1
 \end{aligned}
@@ -594,7 +593,7 @@ $$
 \textrm{Prob}(X\le i)& =(1-\lambda)\sum_{j=0}^{i}\lambda^i\\
 & =(1-\lambda)[\frac{1-\lambda^{i+1}}{1-\lambda}]\\
 & =1-\lambda^{i+1}\\
-& =F(X)=F_i \quad 
+& =F(X)=F_i \quad
 \end{aligned}
 $$
 
@@ -665,23 +664,23 @@ plt.show()
 
 Let's write some Python code to compute   means and variances of some  univariate random variables.
 
-We'll use our code to 
+We'll use our code to
 
 - compute population means and variances from the probability distribution
 - generate  a sample  of $N$ independently and identically distributed draws and compute sample means and variances
 - compare population and sample means and variances
 
-## Geometric distribution  
+## Geometric distribution
 
 $$
-\textrm{Prob}(X=k)=(1-p)^{k-1}p,k=1,2, \ldots 
+\textrm{Prob}(X=k)=(1-p)^{k-1}p,k=1,2, \ldots
 $$
 
 $\implies$
 
 $$
 \begin{aligned}
-\mathbb{E}(X) & =\frac{1}{p}\\\mathbb{D}(X) & =\frac{1-p}{p^2} 
+\mathbb{E}(X) & =\frac{1}{p}\\\mathbb{D}(X) & =\frac{1-p}{p^2}
 \end{aligned}
 $$
 
@@ -707,8 +706,8 @@ print("The population variance is: ", (1-p)/(p**2))
 
 ### Newcomb–Benford distribution
 
-The **Newcomb–Benford law** fits  many data sets, e.g., reports of incomes to tax authorities, in which 
-the leading digit is more likely to be small than large. 
+The **Newcomb–Benford law** fits  many data sets, e.g., reports of incomes to tax authorities, in which
+the leading digit is more likely to be small than large.
 
 See <https://en.wikipedia.org/wiki/Benford%27s_law>
 
@@ -729,7 +728,7 @@ $$
 The mean and variance of a Benford distribution are
 
 $$
-\begin{aligned} 
+\begin{aligned}
 \mathbb{E}\left[X\right]	 &=\sum_{d=1}^{9}d\log_{10}\left(1+\frac{1}{d}\right)\simeq3.4402 \\
 \mathbb{V}\left[X\right]	 & =\sum_{d=1}^{9}\left(d-\mathbb{E}\left[X\right]\right)^{2}\log_{10}\left(1+\frac{1}{d}\right)\simeq6.0565
 \end{aligned}
@@ -760,26 +759,26 @@ plt.title('Benford\'s distribution')
 plt.show()
 ```
 
-### Pascal (negative binomial) distribution 
+### Pascal (negative binomial) distribution
 
 Consider a sequence of independent Bernoulli trials.
 
-Let $p$ be the probability of success. 
+Let $p$ be the probability of success.
 
-Let $X$ be a random variable that represents the number of failures before we get $r$ success. 
+Let $X$ be a random variable that represents the number of failures before we get $r$ success.
 
-Its distribution is 
+Its distribution is
 
-$$ 
+$$
 \begin{aligned}
 X  & \sim NB(r,p) \\
-\textrm{Prob}(X=k;r,p) & = \begin{pmatrix}k+r-1 \\ r-1 \end{pmatrix}p^r(1-p)^{k} 
+\textrm{Prob}(X=k;r,p) & = \begin{pmatrix}k+r-1 \\ r-1 \end{pmatrix}p^r(1-p)^{k}
 \end{aligned}
 $$
 
 Here, we choose from among $k+r-1$ possible outcomes  because the last draw is by definition a success.
 
-We compute the mean and variance to be 
+We compute the mean and variance to be
 
 
 $$
@@ -809,15 +808,15 @@ print("The population variance is: ", r*(1-p)/p**2)
 
 ### Univariate Gaussian distribution
 
-We write 
+We write
 
-$$ 
+$$
 X \sim N(\mu,\sigma^2)
 $$
 
 to indicate the probability distribution
 
-$$f(x|u,\sigma^2)=\frac{1}{\sqrt{2\pi \sigma^2}}e^{[-\frac{1}{2\sigma^2}(x-u)^2]} $$ 
+$$f(x|u,\sigma^2)=\frac{1}{\sqrt{2\pi \sigma^2}}e^{[-\frac{1}{2\sigma^2}(x-u)^2]} $$
 
 In the below example, we set $\mu = 0, \sigma = 0.1$.
 
@@ -856,10 +855,10 @@ $$
 
 The population mean and variance are
 
-$$ 
+$$
 \begin{aligned}
 \mathbb{E}(X) & = \frac{a+b}{2} \\
-\mathbb{V}(X) & = \frac{(b-a)^2}{12} 
+\mathbb{V}(X) & = \frac{(b-a)^2}{12}
 \end{aligned}
 $$
 
@@ -889,11 +888,11 @@ We'll motivate this example with  a little story.
 
 Suppose that  to apply for a job  you take an interview and either pass or fail it.
 
-You have $5\%$ chance to pass an interview and you know your salary will uniformly distributed in the interval 300~400 a day only if you pass. 
+You have $5\%$ chance to pass an interview and you know your salary will uniformly distributed in the interval 300~400 a day only if you pass.
 
 We can describe your daily salary as  a discrete-continuous variable with the following probabilities:
 
-$$ 
+$$
 P(X=0)=0.95
 $$
 
@@ -933,7 +932,7 @@ $$
 \begin{aligned}
 \sigma^2 &= 0.95\times(0-17.5)^2+\int_{300}^{400}(x-17.5)^2f(x)dx \\
 &= 0.95\times17.5^2+0.0005\int_{300}^{400}(x-17.5)^2dx \\
-&= 0.95\times17.5^2+0.0005 \times \frac{1}{3}(x-17.5)^3 \bigg|_{300}^{400} 
+&= 0.95\times17.5^2+0.0005 \times \frac{1}{3}(x-17.5)^3 \bigg|_{300}^{400}
 \end{aligned}
 $$
 
@@ -948,7 +947,7 @@ print("variance: ", var)
 
 Let's use matrices to represent a joint distribution, conditional distribution, marginal distribution, and the mean and variance of a  bivariate random variable.
 
-The table below illustrates a  probability distribution  for a bivariate random variable. 
+The table below illustrates a  probability distribution  for a bivariate random variable.
 
 $$
 F=[f_{ij}]=\left[\begin{array}{cc}
@@ -1246,18 +1245,18 @@ d_new.marg_dist()
 d_new.cond_dist()
 ```
 
-## A Continuous Bivariate Random Vector 
+## A Continuous Bivariate Random Vector
 
 
-A two-dimensional Gaussian distribution has  joint density 
+A two-dimensional Gaussian distribution has  joint density
 
-$$ 
-f(x,y) =(2\pi\sigma_1\sigma_2\sqrt{1-\rho^2})^{-1}\exp\left[-\frac{1}{2(1-\rho^2)}\left(\frac{(x-\mu_1)^2}{\sigma_1^2}-\frac{2\rho(x-\mu_1)(y-\mu_2)}{\sigma_1\sigma_2}+\frac{(y-\mu_2)^2}{\sigma_2^2}\right)\right] 
+$$
+f(x,y) =(2\pi\sigma_1\sigma_2\sqrt{1-\rho^2})^{-1}\exp\left[-\frac{1}{2(1-\rho^2)}\left(\frac{(x-\mu_1)^2}{\sigma_1^2}-\frac{2\rho(x-\mu_1)(y-\mu_2)}{\sigma_1\sigma_2}+\frac{(y-\mu_2)^2}{\sigma_2^2}\right)\right]
 $$
 
 
 $$
-\frac{1}{2\pi\sigma_1\sigma_2\sqrt{1-\rho^2}}\exp\left[-\frac{1}{2(1-\rho^2)}\left(\frac{(x-\mu_1)^2}{\sigma_1^2}-\frac{2\rho(x-\mu_1)(y-\mu_2)}{\sigma_1\sigma_2}+\frac{(y-\mu_2)^2}{\sigma_2^2}\right)\right] 
+\frac{1}{2\pi\sigma_1\sigma_2\sqrt{1-\rho^2}}\exp\left[-\frac{1}{2(1-\rho^2)}\left(\frac{(x-\mu_1)^2}{\sigma_1^2}-\frac{2\rho(x-\mu_1)(y-\mu_2)}{\sigma_1\sigma_2}+\frac{(y-\mu_2)^2}{\sigma_2^2}\right)\right]
 $$
 
 We start with a  bivariate normal distribution pinned down by
@@ -1363,13 +1362,13 @@ The population conditional distribution is
 $$
 \begin{aligned} \\
 [X|Y &= y ]\sim \mathbb{N}\bigg[\mu_X+\rho\sigma_X\frac{y-\mu_Y}{\sigma_Y},\sigma_X^2(1-\rho^2)\bigg] \\
-[Y|X &= x ]\sim \mathbb{N}\bigg[\mu_Y+\rho\sigma_Y\frac{x-\mu_X}{\sigma_X},\sigma_Y^2(1-\rho^2)\bigg] 
-\end{aligned} 
+[Y|X &= x ]\sim \mathbb{N}\bigg[\mu_Y+\rho\sigma_Y\frac{x-\mu_X}{\sigma_X},\sigma_Y^2(1-\rho^2)\bigg]
+\end{aligned}
 $$
 
 Let's approximate  the joint density by discretizing and mapping the approximating joint density into a  matrix.
 
-We can compute the discretized marginal density  by just using matrix algebra and  noting that 
+We can compute the discretized marginal density  by just using matrix algebra and  noting that
 
 $$
 \textrm{Prob}\{X=i|Y=j\}=\frac{f_{ij}}{\sum_{i}f_{ij}}
@@ -1443,12 +1442,12 @@ print(μ2 + ρ * σ2 * (1 - μ1) / σ1, np.sqrt(σ2**2 * (1 - ρ**2)))
 
 Let $X, Y$ be two independent discrete random variables that take values in $\bar{X}, \bar{Y}$, respectively.
 
-Define a new random variable $Z=X+Y$. 
+Define a new random variable $Z=X+Y$.
 
 Evidently, $Z$ takes values from $\bar{Z}$ defined as follows:
 
 $$
-\begin{aligned} 
+\begin{aligned}
 \bar{X} & =\{0,1,\ldots,I-1\};\qquad f_i= \textrm{Prob} \{X=i\}\\
 \bar{Y} & =\{0,1,\ldots,J-1\};\qquad g_j= \textrm{Prob}\{Y=j\}\\
 \bar{Z}& =\{0,1,\ldots,I+J-2\};\qquad h_k=  \textrm{Prob} \{X+Y=k\}
@@ -1466,13 +1465,13 @@ $$
 
 Thus, we have:
 
-$$ 
-h_k=\sum_{i=0}^{k} f_ig_{k-i} \equiv f*g 
+$$
+h_k=\sum_{i=0}^{k} f_ig_{k-i} \equiv f*g
 $$
 
 where $f * g$ denotes the **convolution** of the  $f$ and $g$ sequences.
 
-Similarly, for  two random variables $X,Y$ with  densities $f_{X}, g_{Y}$, the density of $Z=X+Y$ is 
+Similarly, for  two random variables $X,Y$ with  densities $f_{X}, g_{Y}$, the density of $Z=X+Y$ is
 
 $$
 f_{Z}(z)=\int_{-\infty}^{\infty} f_{X}(x) f_{Y}(z-x) dx \equiv f_{X}*g_{Y}
@@ -1490,13 +1489,13 @@ $$
 \textrm{Prob}\{X=i,Y=j\} = \rho_{ij}
 $$
 
-where $i = 0,\dots,I-1; j = 0,\dots,J-1$ and 
+where $i = 0,\dots,I-1; j = 0,\dots,J-1$ and
 
 $$
 \sum_i\sum_j \rho_{ij} = 1, \quad \rho_{ij} \geqslant 0.
 $$
 
-An associated conditional distribution is 
+An associated conditional distribution is
 
 $$
 \textrm{Prob}\{Y=i\vert X=j\} = \frac{\rho_{ij}}{ \sum_{i}\rho_{ij}}
@@ -1509,7 +1508,7 @@ $$
 p_{ij}=\textrm{Prob}\{Y=j|X=i\}= \frac{\rho_{ij}}{ \sum_{j}\rho_{ij}}
 $$
 
-where 
+where
 
 $$
 \left[
@@ -1524,7 +1523,7 @@ The first row is the probability of $Y=j, j=0,1$ conditional on $X=0$.
 
 The second row is the probability of $Y=j, j=0,1$ conditional on $X=1$.
 
-Note that 
+Note that
 - $\sum_{j}\rho_{ij}= \frac{ \sum_{j}\rho_{ij}}{ \sum_{j}\rho_{ij}}=1$, so each row of $\rho$ is a probability distribution (not so for each column.
 
 ## Coupling
@@ -1541,7 +1540,7 @@ j& =0, \cdots，J-1\\
 \end{aligned}
 $$
 
-where 
+where
 
 $$
 \left[
@@ -1552,7 +1551,7 @@ $$
 \right]
 $$
 
-From the joint distribution, we have shown above that we  obtain **unique** marginal distributions. 
+From the joint distribution, we have shown above that we  obtain **unique** marginal distributions.
 
 Now we'll try to go in a reverse direction.
 
@@ -1598,7 +1597,7 @@ $$f_{ij}=
 \right]
 $$
 
-To verify that it is a coupling, we check that 
+To verify that it is a coupling, we check that
 
 $$
 \begin{aligned}
@@ -1637,7 +1636,7 @@ $$
 
 Thus, our two proposed joint distributions have the same marginal distributions.
 
-But the joint distributions differ. 
+But the joint distributions differ.
 
 Thus, multiple  joint distributions $[f_{ij}]$ can have  the same marginals.
 
@@ -1646,12 +1645,12 @@ Thus, multiple  joint distributions $[f_{ij}]$ can have  the same marginals.
 
 ## Copula Functions
 
-Suppose that $X_1, X_2, \dots, X_n$ are $N$ random variables  and that 
+Suppose that $X_1, X_2, \dots, X_n$ are $N$ random variables  and that
 
 * their marginal distributions are $F_1(x_1), F_2(x_2),\dots, F_N(x_N)$,  and
 
 * their joint distribution is $H(x_1,x_2,\dots,x_N)$
-  
+
 Then there exists a **copula function** $C(\cdot)$  that verifies
 
 $$
@@ -1664,10 +1663,10 @@ $$
 C(u_1,u_2,\dots,u_n) = H[F^{-1}_1(u_1),F^{-1}_2(u_2),\dots,F^{-1}_N(u_N)]
 $$
 
-In a reverse direction of logic, given univariate  **marginal distributions** 
+In a reverse direction of logic, given univariate  **marginal distributions**
 $F_1(x_1), F_2(x_2),\dots,F_N(x_N)$ and a copula function $C(\cdot)$, the function $H(x_1,x_2,\dots,x_N) = C(F_1(x_1), F_2(x_2),\dots,F_N(x_N))$ is a **coupling** of $F_1(x_1), F_2(x_2),\dots,F_N(x_N)$.
 
-Thus, for given marginal distributions, we can use  a copula function to determine a joint distribution when the associated univariate  random variables are not independent. 
+Thus, for given marginal distributions, we can use  a copula function to determine a joint distribution when the associated univariate  random variables are not independent.
 
 
 Copula functions are often used to characterize **dependence** of  random variables.
@@ -1896,7 +1895,7 @@ We have verified that both joint distributions, $c_1$ and $c_2$, have identical 
 
 So they are both couplings of $X$ and $Y$.
 
-## Time Series 
+## Time Series
 
 Suppose that there are two time periods.
 
@@ -1904,7 +1903,7 @@ Suppose that there are two time periods.
 - $t=1$  "tomorrow"
 
 Let $X(0)$ be a random variable to be realized at $t=0$, $X(1)$  be a random variable to be realized at $t=1$.
-   
+
 Suppose that
 
 $$
@@ -1920,5 +1919,5 @@ A conditional distribution is
 
 $$\text{Prob} \{X(1)=j|X(0)=i\}= \frac{f_{ij}}{ \sum_{j}f_{ij}}$$
 
-**Remark:** 
+**Remark:**
 - This is a key formula for  a theory of optimally predicting a time series.

--- a/lectures/prob_matrix.md
+++ b/lectures/prob_matrix.md
@@ -34,11 +34,16 @@ Among concepts that we'll be studying include
 We'll use a matrix to represent a bivariate probability distribution and a vector to represent a univariate probability distribution
 
 
-As usual, we'll start with some imports
+In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
-# !pip install prettytable
+---
+tags: [hide-output]
+---
+!pip install prettytable
 ```
+
+As usual, we'll start with some imports
 
 ```{code-cell} ipython3
 import numpy as np

--- a/lectures/prob_meaning.md
+++ b/lectures/prob_meaning.md
@@ -38,11 +38,11 @@ After you are familiar with the material in these videos, this lecture uses the 
  * a frequentist confidence interval
 
  * a Bayesian coverage interval
- 
+
 We do this  by inviting you to  write some  Python code.
- 
-It would be especially useful if you tried doing this after each question that we pose for you,  before 
-proceeding to read the rest of the lecture. 
+
+It would be especially useful if you tried doing this after each question that we pose for you,  before
+proceeding to read the rest of the lecture.
 
 We provide our own answers as the lecture unfolds, but you'll learn more if you try writing your own code before reading and running ours.
 
@@ -65,7 +65,6 @@ import prettytable as pt
 import matplotlib.pyplot as plt
 from scipy.stats import binom
 import scipy.stats as st
-%matplotlib inline
 ```
 
 Empowered with these Python tools, we'll now  explore the two meanings described above.
@@ -74,22 +73,22 @@ Empowered with these Python tools, we'll now  explore the two meanings described
 
 Consider the following classic example.
 
-The random variable  $X $ takes on possible values $k = 0, 1, 2, \ldots, n$  with probabilties 
+The random variable  $X $ takes on possible values $k = 0, 1, 2, \ldots, n$  with probabilties
 
-$$ 
-\textrm{Prob}(X =  k | \theta) = 
+$$
+\textrm{Prob}(X =  k | \theta) =
 \left(\frac{n!}{k! (n-k)!} \right) \theta^k (1-\theta)^{n-k}
-$$ 
+$$
 
 where the fixed parameter $\theta \in (0,1)$.
 
-This is called   the __binomial distribution__.  
+This is called   the __binomial distribution__.
 
-Here 
+Here
 
 * $\theta$ is the probability that one toss of a coin will be a head, an outcome that we encode as  $Y = 1$.
 
-* $1 -\theta$ is the probability that one toss of the coin will be a tail, an outcome that we denote $Y = 0$. 
+* $1 -\theta$ is the probability that one toss of the coin will be a tail, an outcome that we denote $Y = 0$.
 
 * $X$ is the total number of heads that came up after flipping the coin $n$ times.
 
@@ -100,7 +99,7 @@ Take $I$ **independent** sequences of $n$  **independent** flips of the coin
 Notice the repeated use of the adjective **independent**:
 
 * we use it once to describe that we are drawing $n$ independent times from a **Bernoulli** distribution with parameter $\theta$ to arrive at one draw from a **Binomial** distribution with parameters
-$\theta,n$.  
+$\theta,n$.
 
 * we use it again to describe that we are then drawing $I$  sequences of $n$ coin draws.
 
@@ -110,7 +109,7 @@ Let $\sum_{h=1}^n y_h^i$ denote the total number of times  heads come up during 
 
 Let $f_k$ record the fraction of samples of length $n$ for which $\sum_{h=1}^n y_h^i = k$:
 
-$$ 
+$$
 f_k^I = \frac{\textrm{number of samples of length n for which } \sum_{h=1}^n y_h^i = k}{
     I}
 $$
@@ -118,7 +117,7 @@ $$
 The probability  $\textrm{Prob}(X =  k | \theta)$ answers the following question:
 
 * As $I$ becomes large, in what   fraction of  $I$ independent  draws of  $n$ coin flips should we anticipate  $k$ heads to occur?
-  
+
 As usual, a law of large numbers justifies this answer.
 
 ```{exercise}
@@ -142,7 +141,7 @@ Here is one solution:
 class frequentist:
 
     def __init__(self, θ, n, I):
-    
+
         '''
         initialization
         -----------------
@@ -150,42 +149,42 @@ class frequentist:
         θ : probability that one toss of a coin will be a head with Y = 1
         n : number of independent flips in each independent sequence of draws
         I : number of independent sequence of draws
-        
+
         '''
-        
+
         self.θ, self.n, self.I = θ, n, I
-    
+
     def binomial(self, k):
-        
+
         '''compute the theoretical probability for specific input k'''
-        
+
         θ, n = self.θ, self.n
         self.k = k
         self.P = binom.pmf(k, n, θ)
-        
+
     def draw(self):
-        
+
         '''draw n independent flips for I independent sequences'''
-        
+
         θ, n, I = self.θ, self.n, self.I
         sample = np.random.rand(I, n)
         Y = (sample <= θ) * 1
         self.Y = Y
-    
+
     def compute_fk(self, kk):
-        
+
         '''compute f_{k}^I for specific input k'''
-        
+
         Y, I = self.Y, self.I
         K = np.sum(Y, 1)
         f_kI = np.sum(K == kk) / I
         self.f_kI = f_kI
         self.kk = kk
-        
+
     def compare(self):
-        
+
         '''compute and print the comparison'''
-        
+
         n = self.n
         comp = pt.PrettyTable()
         comp.field_names = ['k', 'Theoretical', 'Frequentist']
@@ -214,10 +213,10 @@ Let's do some more calculations.
 
 **Comparison with different $\theta$**
 
-Now we fix 
+Now we fix
 
 $$
-n=20, k=10, I=1,000,000 
+n=20, k=10, I=1,000,000
 $$
 
 We'll vary $\theta$ from $0.01$ to $0.99$ and plot outcomes against $\theta$.
@@ -319,7 +318,7 @@ From the above graphs, we can see that **$I$, the number of independent sequence
 When $I$ becomes larger, the difference between theoretical probability and frequentist estimate becomes smaller.
 
 Also, as long as $I$ is large enough, changing $\theta$ or $n$ does not substantially change the accuracy of the observed fraction
-as an approximation of $\theta$. 
+as an approximation of $\theta$.
 
 The Law of Large Numbers is at work here.
 
@@ -327,7 +326,7 @@ For each draw of an independent sequence, $\textrm{Prob}(X_i =  k | \theta)$  is
 
 $$
 n \cdot \textrm{Prob}(X =  k | \theta) \cdot (1-\textrm{Prob}(X =  k | \theta)).
-$$ 
+$$
 
 So, by the LLN, the average of $P_{k,i}$ converges to:
 
@@ -348,14 +347,14 @@ Instead, we think of it as a **random variable**.
 
 $\theta$ is described by a probability distribution.
 
-But now this probability distribution means something different than a relative frequency that we can anticipate to occur in a large i.i.d. sample. 
+But now this probability distribution means something different than a relative frequency that we can anticipate to occur in a large i.i.d. sample.
 
 Instead, the probability distribution of $\theta$ is now a summary of our views about  likely values of $\theta$ either
 
   * **before** we have seen **any** data at all, or
-  * **before** we have seen **more** data, after we have seen **some** data 
+  * **before** we have seen **more** data, after we have seen **some** data
 
-Thus, suppose that, before seeing any data, you have a personal prior probability distribution saying that 
+Thus, suppose that, before seeing any data, you have a personal prior probability distribution saying that
 
 $$
 P(\theta) = \frac{\theta^{\alpha-1}(1-\theta)^{\beta -1}}{B(\alpha, \beta)}
@@ -367,19 +366,19 @@ a **beta distribution** with parameters $\alpha, \beta$.
 ```{exercise}
 :label: pm_ex2
 
-**a)**  Please write down the **likelihood function** for a sample of length $n$ from a binomial distribution with parameter $\theta$. 
+**a)**  Please write down the **likelihood function** for a sample of length $n$ from a binomial distribution with parameter $\theta$.
 
 **b)** Please write down the **posterior** distribution for $\theta$ after observing  one flip of the coin.
 
 **c)** Now pretend that the true value of $\theta = .4$ and that someone who doesn't know this has a beta prior distribution with parameters  with $\beta = \alpha = .5$. Please write a Python class to simulate this person's personal posterior distribution for $\theta$  for a _single_ sequence of $n$ draws.
 
-**d)** Please plot the posterior distribution for $\theta$ as a function of $\theta$ as $n$ grows as $1, 2, \ldots$.  
+**d)** Please plot the posterior distribution for $\theta$ as a function of $\theta$ as $n$ grows as $1, 2, \ldots$.
 
 **e)** For various $n$'s, please describe and compute  a Bayesian coverage interval for the interval $[.45, .55]$.
 
 **f)** Please tell what question a Bayesian coverage interval answers.
 
-**g)** Please compute the Posterior probabililty that $\theta \in [.45, .55]$ for various values of sample size $n$. 
+**g)** Please compute the Posterior probabililty that $\theta \in [.45, .55]$ for various values of sample size $n$.
 
 **h)** Please use your Python class to study what happens to the posterior distribution as $n \rightarrow + \infty$, again assuming that the true value of $\theta = .4$, though it is unknown to the person doing the updating via Bayes' Law.
 ```
@@ -396,9 +395,9 @@ Suppose the outcome is __Y__.
 The likelihood function is:
 
 $$
-L(Y|\theta)= \textrm{Prob}(X =  Y | \theta) = 
+L(Y|\theta)= \textrm{Prob}(X =  Y | \theta) =
 \theta^Y (1-\theta)^{1-Y}
-$$ 
+$$
 
 **b)** Please write the **posterior** distribution for $\theta$ after observing  one flip of our coin.
 
@@ -408,7 +407,7 @@ $$
 \textrm{Prob}(\theta) = \frac{\theta^{\alpha - 1} (1 - \theta)^{\beta - 1}}{B(\alpha, \beta)}
 $$
 
-We can derive the posterior distribution for $\theta$ via 
+We can derive the posterior distribution for $\theta$ via
 
 \begin{align*}
   \textrm{Prob}(\theta | Y) &= \frac{\textrm{Prob}(Y | \theta) \textrm{Prob}(\theta)}{\textrm{Prob}(Y)} \\
@@ -434,69 +433,69 @@ class Bayesian:
         """
         Parameters:
         ----------
-        θ : float, ranging from [0,1]. 
+        θ : float, ranging from [0,1].
            probability that one toss of a coin will be a head with Y = 1
-            
+
         n : int.
            number of independent flips in an independent sequence of draws
-            
+
         α&β : int or float.
              parameters of the prior distribution on θ
-            
+
         """
         self.θ, self.n, self.α, self.β = θ, n, α, β
         self.prior = st.beta(α, β)
-    
+
     def draw(self):
         """
         simulate a single sequence of draws of length n, given probability θ
-            
+
         """
         array = np.random.rand(self.n)
         self.draws = (array < self.θ).astype(int)
-    
+
     def form_single_posterior(self, step_num):
         """
         form a posterior distribution after observing the first step_num elements of the draws
-        
+
         Parameters
         ----------
-        step_num: int. 
+        step_num: int.
                number of steps observed to form a posterior distribution
-        
+
         Returns
         ------
         the posterior distribution for sake of plotting in the subsequent steps
-        
+
         """
         heads_num = self.draws[:step_num].sum()
         tails_num = step_num - heads_num
-        
+
         return st.beta(self.α+heads_num, self.β+tails_num)
-    
+
     def form_posterior_series(self,num_obs_list):
         """
         form a series of posterior distributions that form after observing different number of draws.
-        
+
         Parameters
         ----------
         num_obs_list: a list of int.
                a list of the number of observations used to form a series of posterior distributions.
-        
+
         """
         self.posterior_list = []
         for num in num_obs_list:
             self.posterior_list.append(self.form_single_posterior(num))
 ```
 
-**d)** Please plot the posterior distribution for $\theta$ as a function of $\theta$ as $n$ grows from $1, 2, \ldots$.  
+**d)** Please plot the posterior distribution for $\theta$ as a function of $\theta$ as $n$ grows from $1, 2, \ldots$.
 
 ```{code-cell} ipython3
 Bay_stat = Bayesian()
 Bay_stat.draw()
 
 num_list = [1, 2, 3, 4, 5, 10, 20, 30, 50, 70, 100, 300, 500, 1000, # this line for finite n
-            5000, 10_000, 50_000, 100_000, 200_000, 300_000]  # this line for approximately infinite n 
+            5000, 10_000, 50_000, 100_000, 200_000, 300_000]  # this line for approximately infinite n
 
 Bay_stat.form_posterior_series(num_list)
 
@@ -510,7 +509,7 @@ for ii, num in enumerate(num_list[:14]):
     ax.plot(θ_values, Bay_stat.posterior_list[ii].pdf(θ_values), label='Posterior with n = %d' % num)
 
 ax.set_title('P.D.F of Posterior Distributions', fontsize=15)
-ax.set_xlabel(r"$\theta$", fontsize=15) 
+ax.set_xlabel(r"$\theta$", fontsize=15)
 
 ax.legend(fontsize=11)
 plt.show()
@@ -544,7 +543,7 @@ $$
 F(a)=p_1,F(b)=p_2
 $$
 
-**g)** Please compute the Posterior probabililty that $\theta \in [.45, .55]$ for various values of sample size $n$. 
+**g)** Please compute the Posterior probabililty that $\theta \in [.45, .55]$ for various values of sample size $n$.
 
 ```{code-cell} ipython3
 left_value, right_value = 0.45, 0.55
@@ -555,22 +554,22 @@ fig, ax = plt.subplots(figsize=(8, 5))
 ax.plot(posterior_prob_list)
 ax.set_title('Posterior Probabililty that '+ r"$\theta$" +' Ranges from %.2f to %.2f'%(left_value, right_value),
              fontsize=13)
-ax.set_xticks(np.arange(0, len(posterior_prob_list), 3))  
+ax.set_xticks(np.arange(0, len(posterior_prob_list), 3))
 ax.set_xticklabels(num_list[::3])
 ax.set_xlabel('Number of Observations', fontsize=11)
 
 plt.show()
 ```
 
-Notice that in the graph above the posterior probabililty that $\theta \in [.45, .55]$ typically exhibits a hump shape as $n$ increases. 
+Notice that in the graph above the posterior probabililty that $\theta \in [.45, .55]$ typically exhibits a hump shape as $n$ increases.
 
-Two opposing forces are at work. 
+Two opposing forces are at work.
 
-The first force is that the individual  adjusts his belief as he observes new outcomes, so his posterior probability distribution  becomes more and more realistic, which explains the rise of the posterior probabililty. 
+The first force is that the individual  adjusts his belief as he observes new outcomes, so his posterior probability distribution  becomes more and more realistic, which explains the rise of the posterior probabililty.
 
-However, $[.45, .55]$ actually excludes the true $\theta =.4 $ that generates the data. 
+However, $[.45, .55]$ actually excludes the true $\theta =.4 $ that generates the data.
 
-As a result, the posterior probabililty drops as larger and larger samples refine his  posterior probability distribution of $\theta$. 
+As a result, the posterior probabililty drops as larger and larger samples refine his  posterior probability distribution of $\theta$.
 
 The descent seems precipitous only because of the scale of the graph  that has the number of observations increasing disproportionately.
 
@@ -587,11 +586,11 @@ fig, ax = plt.subplots(figsize=(10, 6))
 
 for ii, num in enumerate(num_list[14:]):
     ii += 14
-    ax.plot(θ_values, Bay_stat.posterior_list[ii].pdf(θ_values), 
+    ax.plot(θ_values, Bay_stat.posterior_list[ii].pdf(θ_values),
             label='Posterior with n=%d thousand' % (num/1000))
 
 ax.set_title('P.D.F of Posterior Distributions', fontsize=15)
-ax.set_xlabel(r"$\theta$", fontsize=15) 
+ax.set_xlabel(r"$\theta$", fontsize=15)
 ax.set_xlim(0.3, 0.5)
 
 ax.legend(fontsize=11)
@@ -600,9 +599,9 @@ plt.show()
 
 As $n$ increases, we can see that the probability density functions _concentrate_ on $0.4$, the true value of $\theta$.
 
-Here the  posterior means  converges to $0.4$ while the posterior standard deviations converges to $0$ from above. 
+Here the  posterior means  converges to $0.4$ while the posterior standard deviations converges to $0$ from above.
 
-To show this, we compute the means and variances statistics of the posterior distributions. 
+To show this, we compute the means and variances statistics of the posterior distributions.
 
 ```{code-cell} ipython3
 mean_list = [ii.mean() for ii in Bay_stat.posterior_list]
@@ -612,13 +611,13 @@ fig, ax = plt.subplots(1, 2, figsize=(14, 5))
 
 ax[0].plot(mean_list)
 ax[0].set_title('Mean Values of Posterior Distribution', fontsize=13)
-ax[0].set_xticks(np.arange(0, len(mean_list), 3))  
+ax[0].set_xticks(np.arange(0, len(mean_list), 3))
 ax[0].set_xticklabels(num_list[::3])
 ax[0].set_xlabel('Number of Observations', fontsize=11)
 
 ax[1].plot(std_list)
 ax[1].set_title('Standard Deviations of Posterior Distribution', fontsize=13)
-ax[1].set_xticks(np.arange(0, len(std_list), 3))  
+ax[1].set_xticks(np.arange(0, len(std_list), 3))
 ax[1].set_xticklabels(num_list[::3])
 ax[1].set_xlabel('Number of Observations', fontsize=11)
 
@@ -628,7 +627,7 @@ plt.show()
 ```{solution-end}
 ```
 
-How shall we interpret the patterns above? 
+How shall we interpret the patterns above?
 
 The answer is encoded in the  Bayesian updating formulas.
 
@@ -657,15 +656,15 @@ The mean is $\frac{\alpha}{\alpha + \beta}$
 
 The variance is $\frac{\alpha \beta}{(\alpha + \beta)^2 (\alpha + \beta + 1)}$
 
-* $\alpha$ can be viewed as the number of successes 
- 
+* $\alpha$ can be viewed as the number of successes
+
 * $\beta$ can be viewed as the number of failures
 
 The random variables $k$ and $N-k$ are governed by Binomial Distribution with $\theta=0.4$.
 
 Call this the true data generating process.
 
-According to the Law of Large Numbers, for a large number of observations, observed frequencies of $k$ and $N-k$ will be described by the true data generating process, i.e., the population probability distribution that we assumed when generating the observations on the computer. (See {ref}`pm_ex1`). 
+According to the Law of Large Numbers, for a large number of observations, observed frequencies of $k$ and $N-k$ will be described by the true data generating process, i.e., the population probability distribution that we assumed when generating the observations on the computer. (See {ref}`pm_ex1`).
 
 Consequently, the  mean of the posterior distribution converges to $0.4$ and the variance withers to zero.
 
@@ -677,7 +676,7 @@ fig, ax = plt.subplots(figsize=(10, 6))
 ax.scatter(np.arange(len(upper_bound)), upper_bound, label='95 th Quantile')
 ax.scatter(np.arange(len(lower_bound)), lower_bound, label='05 th Quantile')
 
-ax.set_xticks(np.arange(0, len(upper_bound), 2))  
+ax.set_xticks(np.arange(0, len(upper_bound), 2))
 ax.set_xticklabels(num_list[::2])
 ax.set_xlabel('Number of Observations', fontsize=12)
 ax.set_title('Bayesian Coverage Intervals of Posterior Distributions', fontsize=15)
@@ -686,30 +685,30 @@ ax.legend(fontsize=11)
 plt.show()
 ```
 
-After observing a large number of outcomes, the  posterior distribution collapses around $0.4$. 
+After observing a large number of outcomes, the  posterior distribution collapses around $0.4$.
 
-Thus, the Bayesian statististian  comes to believe that $\theta$ is near $.4$. 
+Thus, the Bayesian statististian  comes to believe that $\theta$ is near $.4$.
 
-As shown in the figure above, as the number of observations grows, the Bayesian coverage intervals (BCIs) become narrower and narrower   around  $0.4$. 
+As shown in the figure above, as the number of observations grows, the Bayesian coverage intervals (BCIs) become narrower and narrower   around  $0.4$.
 
 However, if you take a closer look, you will find that the centers of  the BCIs are not exactly $0.4$, due to the persistent influence of the prior distribution and the randomness of the simulation path.
 
 
 ## Role of a Conjugate Prior
 
-We have made  assumptions that link functional forms of  our likelihood function and our prior in a way that has eased our calculations considerably. 
+We have made  assumptions that link functional forms of  our likelihood function and our prior in a way that has eased our calculations considerably.
 
 In particular, our assumptions that the likelihood function is **binomial** and that the prior distribution is a **beta distribution** have the consequence that the posterior distribution implied by Bayes' Law is also a **beta distribution**.
 
-So posterior and prior are both beta distributions, albeit ones with different parameters. 
+So posterior and prior are both beta distributions, albeit ones with different parameters.
 
 When a likelihood function and prior fit together like hand and glove in this way, we can  say that the  prior and posterior are **conjugate distributions**.
 
-In this situation, we also sometimes  say that we have **conjugate prior** for the likelihood function $\textrm{Prob}(X | \theta)$.  
+In this situation, we also sometimes  say that we have **conjugate prior** for the likelihood function $\textrm{Prob}(X | \theta)$.
 
 Typically, the functional form of the likelihood function determines the functional form of a **conjugate prior**.
 
-A natural question to ask is why should a person's personal prior about a parameter $\theta$ be restricted to be described by a conjugate prior? 
+A natural question to ask is why should a person's personal prior about a parameter $\theta$ be restricted to be described by a conjugate prior?
 
 Why not some other functional form that more sincerely describes the person's beliefs.
 
@@ -718,9 +717,8 @@ personal beliefs about $\theta$?
 
 A dignified response to that question is, well, it shouldn't, but if you want to compute a posterior easily you'll just be happier if your prior is conjugate to your likelihood.
 
-Otherwise, your posterior won't have a convenient analytical form and you'll be in the situation of wanting to 
+Otherwise, your posterior won't have a convenient analytical form and you'll be in the situation of wanting to
 apply the Markov chain Monte Carlo techniques deployed in {doc}`this quantecon lecture <bayes_nonconj>`.
 
 We also apply these powerful methods to approximating Bayesian posteriors for non-conjugate priors in
 {doc}`this quantecon lecture <ar1_bayes>` and {doc}`this quantecon lecture <ar1_turningpts>`
-

--- a/lectures/rational_expectations.md
+++ b/lectures/rational_expectations.md
@@ -67,7 +67,6 @@ Except that for us
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -87,7 +86,7 @@ The following setting justifies the concept of a representative firm that stands
 
 There is a uniform unit measure  of identical firms named  $\omega \in \Omega = [0,1]$.
 
-The output of firm $\omega$ is $y(\omega)$.  
+The output of firm $\omega$ is $y(\omega)$.
 
 The output of all firms is $Y = \int_{0}^1 y(\omega) d \, \omega $.
 
@@ -185,19 +184,19 @@ $$
 S_c (Y)= \int_0^Y (a_0 - a_1 s) ds = a_o Y - \frac{a_1}{2} Y^2 .
 $$
 
-Define the social cost of production as 
+Define the social cost of production as
 
 $$ S_p (Y) = c_1 Y + \frac{c_2}{2} Y^2  $$
 
-Consider the planning problem  
+Consider the planning problem
 
 $$
 \max_{Y} [ S_c(Y) - S_p(Y) ]
 $$
 
-The first-order necessary condition for the planning problem is equation {eq}`staticY`.  
+The first-order necessary condition for the planning problem is equation {eq}`staticY`.
 
-Thus, a $Y$ that solves {eq}`staticY` is a competitive equilibrium output as well as an output that solves the planning problem.  
+Thus, a $Y$ that solves {eq}`staticY` is a competitive equilibrium output as well as an output that solves the planning problem.
 
 This type of outcome provides an intellectual justification for liking a competitive equilibrium.
 
@@ -957,4 +956,3 @@ See {cite}`MarcetSargent1989` and {cite}`EvansHonkapohja2001` for statements
 and applications of this approach to establish conditions under which
 collections of adaptive agents who use least squares learning to converge to a
 rational expectations equilibrium.
-

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -37,7 +37,6 @@ tags: [hide-output]
 ```
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -1066,7 +1065,7 @@ Compare $F^*$ with $F_1 + F_2 F^*$
 F_check[0] + F_check[1] * F_star, F_star
 ```
 
-## Fun with SymPy 
+## Fun with SymPy
 
 This section is a  gift for readers who have made it this far.
 
@@ -1161,4 +1160,3 @@ $−(Q^{22})^{−1}Q^{21}$
 ```{code-cell} python3
 - Q_inv[1, 0] / Q_inv[1, 1]
 ```
-

--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -47,7 +47,6 @@ Our objectives are to
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -1434,4 +1433,3 @@ could either be stationary, explosive, or oscillating.
 
 We also were able to represent the model using the [QuantEcon.py](http://quantecon.org/quantecon-py)
 [LinearStateSpace](https://github.com/QuantEcon/QuantEcon.py/blob/master/quantecon/lss.py) class.
-

--- a/lectures/scalar_dynam.md
+++ b/lectures/scalar_dynam.md
@@ -37,7 +37,6 @@ intuition.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/schelling.md
+++ b/lectures/schelling.md
@@ -47,7 +47,6 @@ In this lecture, we (in fact you) will build and run a version of Schelling's mo
 Let's start with some imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 from random import uniform, seed

--- a/lectures/sir_model.md
+++ b/lectures/sir_model.md
@@ -51,7 +51,6 @@ other countries.
 We will use the following standard imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
@@ -412,4 +411,3 @@ plot_paths(paths, labels)
 
 Pushing the peak of curve further into the future may reduce cumulative deaths
 if a vaccine is found.
-

--- a/lectures/svd_intro.md
+++ b/lectures/svd_intro.md
@@ -295,7 +295,6 @@ Let's do an example.
 import numpy as np
 import numpy.linalg as LA
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 Having imported these modules, let's do the example.

--- a/lectures/uncertainty_traps.md
+++ b/lectures/uncertainty_traps.md
@@ -51,7 +51,6 @@ Uncertainty traps stem from a positive externality: high aggregate economic acti
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/util_rand_resp.md
+++ b/lectures/util_rand_resp.md
@@ -660,7 +660,7 @@ and it follows that:
 
 - Hazard for an individual in $A^{'}$ is 0.
 
-- Hazard for an individual in A can also be made arbitrarily small by choosing a sufficiently small $\text{Pr}(\text{yes}|A)$.
+- Hazard for an individual in $A$ can also be made arbitrarily small by choosing a sufficiently small $\text{Pr}(\text{yes}|A)$.
 
 Even though this hazard can be set arbitrarily close to 0, an individual in $A$ will completely reveal his or her identity whenever truthfully answering the sensitive question.
 

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -51,7 +51,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import fsolve, linprog
 from textwrap import dedent
-%matplotlib inline
 
 np.set_printoptions(precision=2)
 ```

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -36,7 +36,6 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install quantecon
 !pip install interpolation
 ```
 
@@ -137,7 +136,7 @@ random variables is also independently and identically distributed (IID).
 But the observer does not know which of the two distributions generated the sequence.
 
 For reasons explained in  [Exchangeability and Bayesian Updating](https://python.quantecon.org/exchangeable.html), this means that the sequence is not
-IID.  
+IID.
 
 The observer has something to learn, namely, whether the observations are drawn from  $f_0$ or from $f_1$.
 

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -76,7 +76,6 @@ At the same time, all of the techniques discussed here can be plugged into model
 We will use the following imports.
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np


### PR DESCRIPTION
This PR

- removes `%matplotlib inline` as no longer required
- removes redundant white space
- removes `+++` markers introduced by `jupytext` conversion

cc @mmcky 