### PR TITLE
ENH: upgrade software stack

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,7 +27,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-07-py310
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-07-py310
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-07-py310
       options: --gpus all
     steps:
       - name: Checkout

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,12 @@ channels:
   - default
 dependencies:
   - python=3.10
-  - anaconda=2023.03
+  - anaconda=2023.07
   - pip
   - pip:
     - jupyter-book==0.15.1
-    - quantecon-book-theme==0.4.1
+    - docutils==0.17.1
+    - quantecon-book-theme==0.5.3
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1


### PR DESCRIPTION
This PR upgrades to `anaconda==2023.07`

- [x] rerun CI when Amazon has availability of `p3.2xlarge` instances

```
InsufficientInstanceCapacity: We currently do not have sufficient p3.2xlarge capacity in the Availability Zone you requested (us-west-2b). Our system will be working on provisioning additional capacity. You can currently get p3.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-west-2a, us-west-2c."}
```