### PR TITLE
MAINT: Upgrade to latest docker 

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,7 +27,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-07-py310-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-07-py310-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-07-py310-b
       options: --gpus all
     steps:
       - name: Checkout

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,11 @@ channels:
   - default
 dependencies:
   - python=3.10
-  - anaconda=2023.03
+  - anaconda=2023.07
   - pip
   - pip:
     - jupyter-book==0.15.1
-    - quantecon-book-theme==0.4.1
+    - quantecon-book-theme==0.6.0
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1


### PR DESCRIPTION
This PR upgrades the `docker` container that has quantecon-book-theme==0.6.0 + anaconda==2023.07