### PR TITLE
cass_koopmans_1.md: typo in attribution of explanation

### DIFF
--- a/lectures/cass_koopmans_1.md
+++ b/lectures/cass_koopmans_1.md
@@ -322,7 +322,7 @@ K_t: \qquad \beta \mu_t\left[(1-\delta)+f'(K_t)\right] - \mu_{t-1}=0 \qquad \tex
 K_{T+1}: \qquad -\mu_T \leq 0, \ \leq 0 \text{ if } K_{T+1}=0; \ =0 \text{ if } K_{T+1}>0
 ```
 
-In computing  {eq}`constraint3` we recognize that $K_t$ appears
+In computing  {eq}`constraint2` we recognize that $K_t$ appears
 in both the time  $t$ and time $t-1$ feasibility constraints {eq}`allocation`.
 
 Restrictions {eq}`constraint4` come from differentiating with respect


### PR DESCRIPTION
The explantion refers to `constraint2` i.e. derivative wrt `K_t`