### PR TITLE
Update author information compat with quantecon-book-theme==0.7.0

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -31,7 +31,7 @@ latex:
    latex_documents:
       targetname: quantecon-python.tex
 
-sphinx:
+sphinx: 
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter, sphinxcontrib.youtube, sphinx.ext.todo, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_reredirects]
   config:
     nb_mime_priority_overrides: [
@@ -69,6 +69,11 @@ sphinx:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
+      authors:  
+        - name: Thomas J. Sargent
+          url: http://www.tomsargent.com/
+        - name: John Stachurski
+          url: https://johnstachurski.net/
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python.myst

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -31,7 +31,7 @@ latex:
    latex_documents:
       targetname: quantecon-python.tex
 
-sphinx: 
+sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter, sphinxcontrib.youtube, sphinx.ext.todo, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_reredirects]
   config:
     nb_mime_priority_overrides: [
@@ -69,7 +69,7 @@ sphinx:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
-      authors:  
+      authors:
         - name: Thomas J. Sargent
           url: http://www.tomsargent.com/
         - name: John Stachurski

--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -11,8 +11,7 @@ kernelspec:
 
 # Intermediate Quantitative Economics with Python
 
-This website presents a set of lectures on quantitative economic modeling, designed and written by
-[Thomas J. Sargent](http://www.tomsargent.com/) and [John Stachurski](https://johnstachurski.net/).
+This website presents a set of lectures on quantitative economic modeling.
 
 ```{tableofcontents}
 ```


### PR DESCRIPTION
This PR applies author update as using `quantecon-book-theme==0.7.0`

@HumphreyYang I had to update the author for this series but I don't think that will be an issue for migration as you are using a different _config.yml for the reorg