### PR TITLE
MAINT: remove matplotlib inline

### DIFF
--- a/lectures/_static/quant-econ.bib
+++ b/lectures/_static/quant-econ.bib
@@ -3,6 +3,14 @@ QuantEcon Bibliography File used in conjuction with sphinxcontrib-bibtex package
 Note: Extended Information (like abstracts, doi, url's etc.) can be found in quant-econ-extendedinfo.bib file in _static/
 ###
 
+@book{Brunton_Kutz_2019, 
+  place={Cambridge}, 
+  title={Data-Driven Science and Engineering: Machine Learning, Dynamical Systems, and Control}, 
+  publisher={Cambridge University Press}, 
+  author={Brunton, Steven L. and Kutz, J. Nathan}, 
+  year={2019}
+}
+
 @article{wallis1980statistical,
   title={The statistical research group, 1942--1945},
   author={Wallis, W Allen},

--- a/lectures/kalman_2.md
+++ b/lectures/kalman_2.md
@@ -51,15 +51,12 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 To conduct simulations, we bring in these imports, as in {doc}`A First Look at the Kalman filter <kalman>`.
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 from quantecon import Kalman, LinearStateSpace
 from collections import namedtuple
 from scipy.stats import multivariate_normal
 import matplotlib as mpl
-
 mpl.rcParams['text.usetex'] = True
 mpl.rcParams['text.latex.preamble'] = r'\usepackage{{amsmath}}'
 ```

--- a/lectures/var_dmd.md
+++ b/lectures/var_dmd.md
@@ -269,7 +269,7 @@ Here an $ m \times n+1 $  data matrix $ \tilde X $ contains many more attributes
 
 Dynamic mode decomposition was introduced by {cite}`schmid2010`,
 
-You can read  about Dynamic Mode Decomposition here {cite}`DMD_book` and here [[BK19](https://python.quantecon.org/zreferences.html#id25)] (section 7.2).
+You can read  about Dynamic Mode Decomposition {cite}`DMD_book` and {cite}`Brunton_Kutz_2019` (section 7.2).
 
 **Dynamic Mode Decomposition** (DMD) computes a rank $ r < p  $ approximation to the least squares regression coefficients $ \hat A $  described by formula {eq}`eq:AhatSVDformula`.
 


### PR DESCRIPTION
This PR address https://github.com/QuantEcon/meta/issues/134 for this repository

- [x] remove `%matplotlib inline`
- [x] check removal of rc.params fig size setting in `kalman2`