### PR TITLE
FIX: remove duplicate entries for bibtex

### DIFF
--- a/lectures/_static/quant-econ.bib
+++ b/lectures/_static/quant-econ.bib
@@ -3,14 +3,6 @@ QuantEcon Bibliography File used in conjuction with sphinxcontrib-bibtex package
 Note: Extended Information (like abstracts, doi, url's etc.) can be found in quant-econ-extendedinfo.bib file in _static/
 ###
 
-@book{Brunton_Kutz_2019, 
-  place={Cambridge}, 
-  title={Data-Driven Science and Engineering: Machine Learning, Dynamical Systems, and Control}, 
-  publisher={Cambridge University Press}, 
-  author={Brunton, Steven L. and Kutz, J. Nathan}, 
-  year={2019}
-}
-
 @article{wallis1980statistical,
   title={The statistical research group, 1942--1945},
   author={Wallis, W Allen},


### PR DESCRIPTION
There is a duplicate error issue in `quant-econ.bib` 

This PR addresses this. 