### PR TITLE
MAINT: migrate to github actions gpu instance, dependabot testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    commit-message:
+      prefix: ⬆️
+    schedule:
+      interval: weekly

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -4,30 +4,10 @@ on:
     branches:
       - main
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v1
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   cache:
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
+    runs-on: quantecon-gpu-runner
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-06-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: quantecon-gpu-runner
+    runs-on: ubuntu-latest-gpu
     container:
       image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-06-py311
       options: --gpus all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   preview:
     runs-on: quantecon-gpu-runner
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-06-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-06-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,13 @@
 name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v2
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   preview:
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
+    runs-on: ubuntu-latest-gpu
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-06-py311
       options: --gpus all
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       # Check nvidia drivers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: ubuntu-latest-gpu
+    runs-on: quantecon-gpu-runner
     container:
       image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-06-py311
       options: --gpus all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,31 +4,11 @@ on:
     tags:
       - 'publish*'
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v1
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
+    runs-on: quantecon-gpu-runner
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-06-py311
       options: --gpus all
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR

- [x] migrates to using github actions based gpu instances
- [x] enables dependabot testing for github actions versions
- [x] updates ci workflow
- [x] updates all workflows 
- [ ] check full run execution
- [ ] re-enable build cache