### PR TITLE
MAINT: add nvidia-smi output to status page

### DIFF
--- a/lectures/status.md
+++ b/lectures/status.md
@@ -32,3 +32,9 @@ and the following package versions
 :tags: [hide-output]
 !conda list
 ```
+
+This lecture series also has access to the following GPU
+
+```{code-cell} ipython
+!nvidia-smi
+```


### PR DESCRIPTION
Add check for `GPU` on the status page.

Helps to close issues such as https://github.com/QuantEcon/lecture-python.myst/issues/323 to verify access to GPU. 