### PR TITLE
FIX: pass quantecon logo through to download notebooks

### DIFF
--- a/lectures/aiyagari.md
+++ b/lectures/aiyagari.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (aiyagari)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (career)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/cass_koopmans_1.md
+++ b/lectures/cass_koopmans_1.md
@@ -12,7 +12,7 @@ kernelspec:
 ---
 
 (cass_koopmans_1)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (cass_koopmans_2)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/coleman_policy_iter.md
+++ b/lectures/coleman_policy_iter.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/egm_policy_iter.md
+++ b/lectures/egm_policy_iter.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (odu_v3)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (mc)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/harrison_kreps.md
+++ b/lectures/harrison_kreps.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (harrison_kreps)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/ifp.md
+++ b/lectures/ifp.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (jv)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/kalman.md
+++ b/lectures/kalman.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (kalman)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/kalman_2.md
+++ b/lectures/kalman_2.md
@@ -12,7 +12,7 @@ kernelspec:
 ---
 
 (kalman)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (lake_model)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (likelihood_ratio_process)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (likelihood_ratio_process)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/linear_algebra.md
+++ b/lectures/linear_algebra.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (linear_algebra)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/linear_models.md
+++ b/lectures/linear_models.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (lssm)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (lln_clt)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/lq_inventories.md
+++ b/lectures/lq_inventories.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (inventory_sales_smoothing-v6)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (lqc)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (mass)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/markov_perf.md
+++ b/lectures/markov_perf.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (markov_perf)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/mccall_correlated.md
+++ b/lectures/mccall_correlated.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/mccall_fitted_vfi.md
+++ b/lectures/mccall_fitted_vfi.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/mccall_model.md
+++ b/lectures/mccall_model.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (mccall)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/mccall_model_with_separation.md
+++ b/lectures/mccall_model_with_separation.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (mccall_with_sep)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/multi_hyper.md
+++ b/lectures/multi_hyper.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (multi_hyper_v7)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (multivariate_normal_v11)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (bayesian_vs_frequentist__v1)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/newton_method.md
+++ b/lectures/newton_method.md
@@ -12,7 +12,7 @@ kernelspec:
 ---
 
 (newton_method)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (odu_v2)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/opt_transport.md
+++ b/lectures/opt_transport.md
@@ -265,7 +265,7 @@ The table below provides numbers for the requirements vector $q$, the capacity v
 and entries $c_{ij}$  of the cost-of-shipping matrix $C$.
 
 
-```{raw} html
+```{raw} jupyter
 <table>
     <tr>
 	    <th> </th>

--- a/lectures/opt_transport.md
+++ b/lectures/opt_transport.md
@@ -265,7 +265,7 @@ The table below provides numbers for the requirements vector $q$, the capacity v
 and entries $c_{ij}$  of the cost-of-shipping matrix $C$.
 
 
-```{raw} jupyter
+```{raw} html
 <table>
     <tr>
 	    <th> </th>

--- a/lectures/optgrowth.md
+++ b/lectures/optgrowth.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (optgrowth)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/optgrowth_fast.md
+++ b/lectures/optgrowth_fast.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (optgrowth)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (ppd)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (perm_income)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/perm_income_cons.md
+++ b/lectures/perm_income_cons.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (perm_income_cons)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/rational_expectations.md
+++ b/lectures/rational_expectations.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (ree)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (re_with_feedback)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/sir_model.md
+++ b/lectures/sir_model.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (troubleshooting)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/uncertainty_traps.md
+++ b/lectures/uncertainty_traps.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (uncertainty_traps)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -10,7 +10,7 @@ kernelspec:
 ---
 
 (von_neumann_model)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -12,7 +12,7 @@ kernelspec:
 ---
 
 (wald_friedman)=
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -9,7 +9,7 @@ kernelspec:
   name: python3
 ---
 
-```{raw} html
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">


### PR DESCRIPTION
This PR improves the download notebooks and fixes #51 

- [x] check download notebooks include `QuantEcon` logo header
- [x] check `html` has not changes