### PR TITLE
FIX: syntax for strings python>=3.12

### DIFF
--- a/lectures/ak2.md
+++ b/lectures/ak2.md
@@ -760,8 +760,8 @@ fig, axs = plt.subplots(3, 3, figsize=(14, 10))
 # quantities
 for i, name in enumerate(['K', 'Y', 'Cy', 'Co']):
     ax = axs[i//3, i%3]
-    ax.plot(range(T+1), quant_seq1[:T+1, i], label=name+', 1/3')
-    ax.plot(range(T+1), quant_seq2[:T+1, i], label=name+', 0.2')
+    ax.plot(range(T+1), quant_seq1[:T+1, i], label=f'{name}, 1/3')
+    ax.plot(range(T+1), quant_seq2[:T+1, i], label=f'{name}, 0.2')
     ax.hlines(init_ss[i], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -769,8 +769,8 @@ for i, name in enumerate(['K', 'Y', 'Cy', 'Co']):
 # prices
 for i, name in enumerate(['W', 'r']):
     ax = axs[(i+4)//3, (i+4)%3]
-    ax.plot(range(T+1), price_seq1[:T+1, i], label=name+', 1/3')
-    ax.plot(range(T+1), price_seq2[:T+1, i], label=name+', 0.2')
+    ax.plot(range(T+1), price_seq1[:T+1, i], label=f'{name}, 1/3')
+    ax.plot(range(T+1), price_seq2[:T+1, i], label=f'{name}, 0.2')
     ax.hlines(init_ss[i+4], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -778,8 +778,8 @@ for i, name in enumerate(['W', 'r']):
 # policies
 for i, name in enumerate(['τ', 'D', 'G']):
     ax = axs[(i+6)//3, (i+6)%3]
-    ax.plot(range(T+1), policy_seq1[:T+1, i], label=name+', 1/3')
-    ax.plot(range(T+1), policy_seq2[:T+1, i], label=name+', 0.2')
+    ax.plot(range(T+1), policy_seq1[:T+1, i], label=f'{name}, 1/3')
+    ax.plot(range(T+1), policy_seq2[:T+1, i], label=f'{name}, 0.2')
     ax.hlines(init_ss[i+6], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -1179,8 +1179,8 @@ fig, axs = plt.subplots(3, 3, figsize=(14, 10))
 # quantities
 for i, name in enumerate(['K', 'Y', 'Cy', 'Co']):
     ax = axs[i//3, i%3]
-    ax.plot(range(T+1), quant_seq3[:T+1, i], label=name+', $\delta$s=0')
-    ax.plot(range(T+1), quant_seq4[:T+1, i], label=name+', $\delta$s=0.005')
+    ax.plot(range(T+1), quant_seq3[:T+1, i], label=rf'{name}, $\delta$s=0')
+    ax.plot(range(T+1), quant_seq4[:T+1, i], label=rf'{name}, $\delta$s=0.005')
     ax.hlines(init_ss[i], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -1188,8 +1188,8 @@ for i, name in enumerate(['K', 'Y', 'Cy', 'Co']):
 # prices
 for i, name in enumerate(['W', 'r']):
     ax = axs[(i+4)//3, (i+4)%3]
-    ax.plot(range(T+1), price_seq3[:T+1, i], label=name+', $\delta$s=0')
-    ax.plot(range(T+1), price_seq4[:T+1, i], label=name+', $\delta$s=0.005')
+    ax.plot(range(T+1), price_seq3[:T+1, i], label=rf'{name}, $\delta$s=0')
+    ax.plot(range(T+1), price_seq4[:T+1, i], label=rf'{name}, $\delta$s=0.005')
     ax.hlines(init_ss[i+4], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -1197,8 +1197,8 @@ for i, name in enumerate(['W', 'r']):
 # policies
 for i, name in enumerate(['τ', 'D', 'G']):
     ax = axs[(i+6)//3, (i+6)%3]
-    ax.plot(range(T+1), policy_seq3[:T+1, i], label=name+', $\delta$s=0')
-    ax.plot(range(T+1), policy_seq4[:T+1, i], label=name+', $\delta$s=0.005')
+    ax.plot(range(T+1), policy_seq3[:T+1, i], label=rf'{name}, $\delta$s=0')
+    ax.plot(range(T+1), policy_seq4[:T+1, i], label=rf'{name}, $\delta$s=0.005')
     ax.hlines(init_ss[i+6], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -1244,8 +1244,8 @@ fig, axs = plt.subplots(3, 3, figsize=(14, 10))
 # quantities
 for i, name in enumerate(['K', 'Y', 'Cy', 'Co']):
     ax = axs[i//3, i%3]
-    ax.plot(range(T+1), quant_seq3[:T+1, i], label=name+', tax cut')
-    ax.plot(range(T+1), quant_seq5[:T+1, i], label=name+', transfer')
+    ax.plot(range(T+1), quant_seq3[:T+1, i], label=f'{name}, tax cut')
+    ax.plot(range(T+1), quant_seq5[:T+1, i], label=f'{name}, transfer')
     ax.hlines(init_ss[i], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -1253,8 +1253,8 @@ for i, name in enumerate(['K', 'Y', 'Cy', 'Co']):
 # prices
 for i, name in enumerate(['W', 'r']):
     ax = axs[(i+4)//3, (i+4)%3]
-    ax.plot(range(T+1), price_seq3[:T+1, i], label=name+', tax cut')
-    ax.plot(range(T+1), price_seq5[:T+1, i], label=name+', transfer')
+    ax.plot(range(T+1), price_seq3[:T+1, i], label=f'{name}, tax cut')
+    ax.plot(range(T+1), price_seq5[:T+1, i], label=f'{name}, transfer')
     ax.hlines(init_ss[i+4], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')
@@ -1262,8 +1262,8 @@ for i, name in enumerate(['W', 'r']):
 # policies
 for i, name in enumerate(['τ', 'D', 'G']):
     ax = axs[(i+6)//3, (i+6)%3]
-    ax.plot(range(T+1), policy_seq3[:T+1, i], label=name+', tax cut')
-    ax.plot(range(T+1), policy_seq5[:T+1, i], label=name+', transfer')
+    ax.plot(range(T+1), policy_seq3[:T+1, i], label=f'{name}, tax cut')
+    ax.plot(range(T+1), policy_seq5[:T+1, i], label=f'{name}, transfer')
     ax.hlines(init_ss[i+6], 0, T+1, color='r', linestyle='--')
     ax.legend()
     ax.set_xlabel('t')

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -16,7 +16,7 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install --upgrade jax jaxlib
+!pip install --upgrade jax jaxlib kaleido
 !conda install -y -c plotly plotly plotly-orca retrying
 ```
 

--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -1242,11 +1242,11 @@ The following code snippet provides a hint as to how you can go about this
 
 ```{code-cell} python3
 import re
-re.findall('\w', 'x +++ y ****** z')  # \w matches alphanumerics
+re.findall(r'\w', 'x +++ y ****** z')  # \w matches alphanumerics
 ```
 
 ```{code-cell} python3
-re.findall('\w', 'a ^^ b &&& $$ c')
+re.findall(r'\w', 'a ^^ b &&& $$ c')
 ```
 
 When you solve for the ranking, you will find that the highest ranked node is in fact `g`, while the lowest is `a`.

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -801,7 +801,7 @@ for pi in pi_array:
 fig, ax = plt.subplots()
 ax.plot(pi_array, cond_var_array)
 ax.set_xlabel(r'$\pi_{t-1}$')
-ax.set_ylabel(r'$\sigma^{2}(\pi_{t}\\vert \pi_{t-1})$')
+ax.set_ylabel(r'$\sigma^{2}(\pi_{t}\vert \pi_{t-1})$')
 plt.show()
 ```
 

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -646,7 +646,7 @@ for i in range(100):
     ax.plot(range(T+1), π_path[i, :])
 
 ax.set_xlabel('$t$')
-ax.set_ylabel('$\pi_t$')
+ax.set_ylabel(r'$\pi_t$')
 plt.show()
 ```
 
@@ -672,7 +672,7 @@ for t in [1, 10, T-1]:
     ax.hist(π_path[:,t], bins=20, alpha=0.4, label=f'T={t}')
 
 ax.set_ylabel('count')
-ax.set_xlabel('$\pi_T$')
+ax.set_xlabel(r'$\pi_T$')
 ax.legend(loc='lower right')
 plt.show()
 ```
@@ -705,7 +705,7 @@ for t in [1, 10, T-1]:
     ax.hist(π_path3[:,t], bins=20, alpha=0.4, label=f'T={t}')
 
 ax.set_ylabel('count')
-ax.set_xlabel('$\pi_T$')
+ax.set_xlabel(r'$\pi_T$')
 ax.legend(loc='upper right')
 plt.show()
 ```
@@ -726,12 +726,12 @@ $F$ more frequently along a sample path, and this pushes $\pi_t$ toward $0$.
 ```{code-cell} ipython3
 fig, ax = plt.subplots()
 for i, j in enumerate([10, 100]):
-    ax.plot(range(T+1), π_path[j,:], color=colors[i], label=f'$\pi$_path, {j}-th simulation')
-    ax.plot(range(1,T+1), w_path[j,:], color=colors[i], label=f'$w$_path, {j}-th simulation', alpha=0.3)
+    ax.plot(range(T+1), π_path[j,:], color=colors[i], label=fr'$\pi$_path, {j}-th simulation')
+    ax.plot(range(1,T+1), w_path[j,:], color=colors[i], label=fr'$w$_path, {j}-th simulation', alpha=0.3)
 
 ax.legend(loc='upper right')
 ax.set_xlabel('$t$')
-ax.set_ylabel('$\pi_t$')
+ax.set_ylabel(r'$\pi_t$')
 ax2 = ax.twinx()
 ax2.set_ylabel("$w_t$")
 plt.show()
@@ -800,8 +800,8 @@ for pi in pi_array:
 
 fig, ax = plt.subplots()
 ax.plot(pi_array, cond_var_array)
-ax.set_xlabel('$\pi_{t-1}$')
-ax.set_ylabel('$\sigma^{2}(\pi_{t}\\vert \pi_{t-1})$')
+ax.set_xlabel(r'$\pi_{t-1}$')
+ax.set_ylabel(r'$\sigma^{2}(\pi_{t}\\vert \pi_{t-1})$')
 plt.show()
 ```
 

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -314,7 +314,7 @@ for t in range(T):
 fig, ax1 = plt.subplots()
 
 for i in range(2):
-    ax1.plot(range(T+1), π_seq_f[i, :], label=f"$\pi_0$={π_seq_f[i, 0]}")
+    ax1.plot(range(T+1), π_seq_f[i, :], label=fr"$\pi_0$={π_seq_f[i, 0]}")
 
 ax1.set_ylabel("$\pi_t$")
 ax1.set_xlabel("t")
@@ -348,7 +348,7 @@ for t in range(T):
 fig, ax1 = plt.subplots()
 
 for i in range(2):
-    ax1.plot(range(T+1), π_seq_g[i, :], label=f"$\pi_0$={π_seq_g[i, 0]}")
+    ax1.plot(range(T+1), π_seq_g[i, :], label=fr"$\pi_0$={π_seq_g[i, 0]}")
 
 ax1.set_ylabel("$\pi_t$")
 ax1.set_xlabel("t")

--- a/lectures/linear_models.md
+++ b/lectures/linear_models.md
@@ -738,7 +738,7 @@ y = y.flatten()
 ygrid = np.linspace(ymin, ymax, 150)
 
 ax.hist(y, bins=50, density=True, alpha=0.4)
-ax.plot(ygrid, f_y.pdf(ygrid), 'k-', lw=2, alpha=0.8, label=r'true density')
+ax.plot(ygrid, f_y.pdf(ygrid), 'k-', lw=2, alpha=0.8, label='true density')
 ax.set_xlim(ymin, ymax)
 ax.set_xlabel('$y_t$', fontsize=12)
 ax.set_ylabel('relative frequency', fontsize=12)
@@ -802,7 +802,7 @@ for t in range(T):
     μ_x, μ_y, Σ_x, Σ_y = next(m)
     population_means.append(float(μ_y))
 
-ax.plot(population_means, color='g', lw=2, alpha=0.8, label='$G\mu_t$')
+ax.plot(population_means, color='g', lw=2, alpha=0.8, label=r'$G\mu_t$')
 ax.set_ylim(ymin, ymax)
 ax.set_xlabel('time', fontsize=12)
 ax.set_ylabel('$y_t$', fontsize=12)

--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -265,7 +265,7 @@ for ax in axes:
     axlabel = '$\\bar{X}_n$ for $X_i \sim$' + name
     ax.plot(list(range(n)), sample_mean, 'g-', lw=3, alpha=0.6, label=axlabel)
     m = distribution.mean()
-    ax.plot(list(range(n)), [m] * n, 'k--', lw=1.5, label='$\mu$')
+    ax.plot(list(range(n)), [m] * n, 'k--', lw=1.5, label=r'$\mu$')
     ax.vlines(list(range(n)), m, data, lw=0.2)
     ax.legend(**legend_args, fontsize=12)
 
@@ -408,7 +408,7 @@ xmin, xmax = -3 * s, 3 * s
 ax.set_xlim(xmin, xmax)
 ax.hist(Y, bins=60, alpha=0.5, density=True)
 xgrid = np.linspace(xmin, xmax, 200)
-ax.plot(xgrid, norm.pdf(xgrid, scale=s), 'k-', lw=2, label='$N(0, \sigma^2)$')
+ax.plot(xgrid, norm.pdf(xgrid, scale=s), 'k-', lw=2, label=r'$N(0, \sigma^2)$')
 ax.legend()
 
 plt.show()

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -455,7 +455,7 @@ def plot_π_seq(α, π1=0.2, π2=0.8, T=200):
     # plot
     fig, ax1 = plt.subplots()
     for i in range(2):
-        ax1.plot(range(T+1), π_seq_mixed[i, :], label=f"$\pi_0$={π_seq_mixed[i, 0]}")
+        ax1.plot(range(T+1), π_seq_mixed[i, :], label=fr"$\pi_0$={π_seq_mixed[i, 0]}")
 
     ax1.plot(np.nan, np.nan,  '--', color='b', label='Log likelihood ratio process')
     ax1.set_ylabel("$\pi_t$")

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -630,7 +630,7 @@ ax.set_xlabel(r'$\alpha$')
 # plot KL
 ax2 = ax.twinx()
 # plot limit point
-ax2.scatter(α_arr_x, π_lim_arr, facecolors='none', edgecolors='tab:blue', label='$\pi$ lim')
+ax2.scatter(α_arr_x, π_lim_arr, facecolors='none', edgecolors='tab:blue', label=r'$\pi$ lim')
 ax2.set_ylabel('π lim')
 
 ax.legend(loc=[0.85, 0.8])
@@ -718,9 +718,9 @@ for i in range(len(sizes)):
         data=sample, kde=True, stat='density', alpha=0.2, ax=ax,
         color=colors[i], binwidth=0.02, linewidth=0.05, label=f't={sizes[i]}'
     )
-ax.set_title('$\pi_t(\\alpha)$ as $t$ increases')
+ax.set_title(r'$\pi_t(\\alpha)$ as $t$ increases')
 ax.legend()
-ax.set_xlabel('$\\alpha$')
+ax.set_xlabel(r'$\\alpha$')
 plt.show()
 ```
 

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -718,9 +718,9 @@ for i in range(len(sizes)):
         data=sample, kde=True, stat='density', alpha=0.2, ax=ax,
         color=colors[i], binwidth=0.02, linewidth=0.05, label=f't={sizes[i]}'
     )
-ax.set_title(r'$\pi_t(\\alpha)$ as $t$ increases')
+ax.set_title(r'$\pi_t(\alpha)$ as $t$ increases')
 ax.legend()
-ax.set_xlabel('$\\alpha$')
+ax.set_xlabel(r'$\alpha$')
 plt.show()
 ```
 

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -455,7 +455,7 @@ def plot_π_seq(α, π1=0.2, π2=0.8, T=200):
     # plot
     fig, ax1 = plt.subplots()
     for i in range(2):
-        ax1.plot(range(T+1), π_seq_mixed[i, :], label=fr"$\pi_0$={π_seq_mixed[i, 0]}")
+        ax1.plot(range(T+1), π_seq_mixed[i, :], label=rf"$\pi_0$={π_seq_mixed[i, 0]}")
 
     ax1.plot(np.nan, np.nan,  '--', color='b', label='Log likelihood ratio process')
     ax1.set_ylabel("$\pi_t$")
@@ -720,7 +720,7 @@ for i in range(len(sizes)):
     )
 ax.set_title(r'$\pi_t(\\alpha)$ as $t$ increases')
 ax.legend()
-ax.set_xlabel(r'$\\alpha$')
+ax.set_xlabel('$\\alpha$')
 plt.show()
 ```
 

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -773,7 +773,7 @@ for i in range(1, n+1):
 μθ_hat_higher = μθ_hat_arr + 1.96 * σθ_hat_arr
 
 plt.hlines(θ, 1, n+1, ls='--', label='true $θ$')
-plt.plot(range(1, n+1), μθ_hat_arr, color='b', label='$\hat{μ}_{θ}$')
+plt.plot(range(1, n+1), μθ_hat_arr, color='b', label=r'$\hat{μ}_{θ}$')
 plt.plot(range(1, n+1), μθ_hat_lower, color='b', ls='--')
 plt.plot(range(1, n+1), μθ_hat_higher, color='b', ls='--')
 plt.fill_between(range(1, n+1), μθ_hat_lower, μθ_hat_higher,
@@ -2277,7 +2277,7 @@ coordinate axis versus $y$ on the ordinate axis.
 
 ```{code-cell} python3
 plt.scatter(range(N), Λ @ f, label='$Ey|f$')
-plt.scatter(range(N), y_hat, label='$\hat{y}$')
+plt.scatter(range(N), y_hat, label=r'$\hat{y}$')
 plt.hlines(f[0], 0, N//2-1, ls='--', label='$f_{1}$')
 plt.hlines(f[1], N//2, N-1, ls='-.', label='$f_{2}$')
 

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -394,9 +394,9 @@ def compute_V_fre(L0_arr, L1_arr, π_star, wf):
 π_star = 0.5
 V_fre_arr, PFA_arr, PD_arr = compute_V_fre(L0_arr, L1_arr, π_star, wf)
 
-plt.plot(range(T), V_fre_arr, label='$\min_{d} \overline{V}_{fre}(t,d)$')
+plt.plot(range(T), V_fre_arr, label=r'$\min_{d} \overline{V}_{fre}(t,d)$')
 plt.xlabel('t')
-plt.title('$\pi^*=0.5$')
+plt.title(r'$\pi^*=0.5$')
 plt.legend()
 plt.show()
 ```
@@ -434,8 +434,8 @@ for i, π_star in enumerate(π_star_arr):
 
 ```{code-cell} python3
 plt.plot(π_star_arr, V_fre_bar_arr)
-plt.xlabel('$\pi^*$')
-plt.title('$\overline{V}_{fre}$')
+plt.xlabel(r'$\pi^*$')
+plt.title(r'$\overline{V}_{fre}$')
 
 plt.show()
 ```
@@ -447,12 +447,12 @@ $\left(PFA,PD\right)$ change as $\pi^{*}$ varies.
 fig, axs = plt.subplots(1, 2, figsize=(14, 5))
 
 axs[0].plot(π_star_arr, t_optimal_arr)
-axs[0].set_xlabel('$\pi^*$')
+axs[0].set_xlabel(r'$\pi^*$')
 axs[0].set_title('optimal sample size given $\pi^*$')
 
 axs[1].plot(π_star_arr, PFA_optimal_arr, label='$PFA^*(\pi^*)$')
 axs[1].plot(π_star_arr, PD_optimal_arr, label='$PD^*(\pi^*)$')
-axs[1].set_xlabel('$\pi^*$')
+axs[1].set_xlabel(r'$\pi^*$')
 axs[1].legend()
 axs[1].set_title('optimal PFA and PD given $\pi^*$')
 
@@ -587,7 +587,7 @@ plt.vlines(β, 0, β * wf.L0, linestyle="--")
 plt.vlines(α, 0, (1 - α) * wf.L1, linestyle="--")
 
 ax.set(xlim=(0, 1), ylim=(0, 0.5 * max(wf.L0, wf.L1)), ylabel="cost",
-       xlabel="$\pi$", title="Value function")
+       xlabel=r"$\pi$", title="Value function")
 
 plt.legend(borderpad=1.1)
 plt.show()
@@ -689,7 +689,7 @@ plt.vlines(β, 0, wf.L0, linestyle='--')
 plt.text(β+0.01, wf.L0/2, 'β')
 plt.vlines(α, 0, wf.L0, linestyle='--')
 plt.text(α+0.01, wf.L0/2, 'α')
-plt.xlabel('$\pi$')
+plt.xlabel(r'$\pi$')
 plt.title('Objective value function $V(\pi)$')
 plt.legend()
 plt.show()
@@ -734,11 +734,11 @@ for i, π_star in enumerate(π_star_arr):
     axs[row_i, col_i].vlines(π_optimal, V_baye_bar, V_baye.max(), linestyle='--')
     axs[row_i, col_i].text(π_optimal+0.05, (V_baye_bar + V_baye.max()) / 2,
                         '${\pi_0^*}=$'+f'{π_optimal:0.2f}')
-    axs[row_i, col_i].set_xlabel('$\pi$')
-    axs[row_i, col_i].set_ylabel('$\overline{V}_{baye}(\pi)$')
-    axs[row_i, col_i].set_title('$\pi^*=$' + f'{π_star}')
+    axs[row_i, col_i].set_xlabel(r'$\pi$')
+    axs[row_i, col_i].set_ylabel(r'$\overline{V}_{baye}(\pi)$')
+    axs[row_i, col_i].set_title(r'$\pi^*=$' + f'{π_star}')
 
-fig.suptitle('$\overline{V}_{baye}(\pi)=\pi^*V^0(\pi) + (1-\pi^*)V^1(\pi)$', fontsize=16)
+fig.suptitle(r'$\overline{V}_{baye}(\pi)=\pi^*V^0(\pi) + (1-\pi^*)V^1(\pi)$', fontsize=16)
 plt.show()
 ```
 
@@ -763,14 +763,14 @@ for i, π_star in enumerate(π_star_arr):
 fig, axs = plt.subplots(1, 2, figsize=(14, 5))
 
 axs[0].plot(π_star_arr, V_baye_bar_arr)
-axs[0].set_xlabel('$\pi^*$')
-axs[0].set_title('$\overline{V}_{baye}$')
+axs[0].set_xlabel(r'$\pi^*$')
+axs[0].set_title(r'$\overline{V}_{baye}$')
 
 axs[1].plot(π_star_arr, π_optimal_arr, label='optimal prior')
 axs[1].plot([π_star_arr.min(), π_star_arr.max()],
             [π_star_arr.min(), π_star_arr.max()],
             c='k', linestyle='--', label='45 degree line')
-axs[1].set_xlabel('$\pi^*$')
+axs[1].set_xlabel(r'$\pi^*$')
 axs[1].set_title('optimal prior given $\pi^*$')
 axs[1].legend()
 
@@ -799,10 +799,10 @@ V_baye_bar = V_baye.min()
 ```
 
 ```{code-cell} python3
-plt.plot(range(T), V_fre_arr, label='$\min_{d} \overline{V}_{fre}(t,d)$')
-plt.plot([0, T], [V_baye_bar, V_baye_bar], label='$\overline{V}_{baye}$')
+plt.plot(range(T), V_fre_arr, label=r'$\min_{d} \overline{V}_{fre}(t,d)$')
+plt.plot([0, T], [V_baye_bar, V_baye_bar], label=r'$\overline{V}_{baye}$')
 plt.xlabel('t')
-plt.title('$\pi^*=0.5$')
+plt.title(r'$\pi^*=0.5$')
 plt.legend()
 plt.show()
 ```
@@ -816,14 +816,14 @@ rule does better on average for all values of $\pi^{*}$.
 ```{code-cell} python3
 fig, axs = plt.subplots(1, 2, figsize=(14, 5))
 
-axs[0].plot(π_star_arr, V_fre_bar_arr, label='$\overline{V}_{fre}$')
-axs[0].plot(π_star_arr, V_baye_bar_arr, label='$\overline{V}_{baye}$')
+axs[0].plot(π_star_arr, V_fre_bar_arr, label=r'$\overline{V}_{fre}$')
+axs[0].plot(π_star_arr, V_baye_bar_arr, label=r'$\overline{V}_{baye}$')
 axs[0].legend()
-axs[0].set_xlabel('$\pi^*$')
+axs[0].set_xlabel(r'$\pi^*$')
 
 axs[1].plot(π_star_arr, V_fre_bar_arr - V_baye_bar_arr, label='$diff$')
 axs[1].legend()
-axs[1].set_xlabel('$\pi^*$')
+axs[1].set_xlabel(r'$\pi^*$')
 
 plt.show()
 ```

--- a/lectures/util_rand_resp.md
+++ b/lectures/util_rand_resp.md
@@ -281,11 +281,11 @@ y2 = (pow(x2, 0.5) - 0.4)**2
 x3 = np.arange(0.4**0.5, 1, 0.001)
 y3 = pow(x3**2 - 0.4, 0.5)
 plt.figure(figsize=(12, 10))
-plt.plot(x1, y1, 'r-', label='Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-Pr(A|r_i)+f(\phi_i)$')
+plt.plot(x1, y1, 'r-', label=r'Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-Pr(A|r_i)+f(\phi_i)$')
 plt.fill_between(x1, 0, y1, facecolor='red', alpha=0.05)
-plt.plot(x2, y2, 'b-', label='Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-Pr(A|r_i)^{2}+f(\phi_i)$')
+plt.plot(x2, y2, 'b-', label=r'Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-Pr(A|r_i)^{2}+f(\phi_i)$')
 plt.fill_between(x2, 0, y2, facecolor='blue', alpha=0.05)
-plt.plot(x3, y3, 'y-', label='Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-\sqrt{Pr(A|r_i)}+f(\phi_i)$')
+plt.plot(x3, y3, 'y-', label=r'Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-\sqrt{Pr(A|r_i)}+f(\phi_i)$')
 plt.fill_between(x3, 0, y3, facecolor='green', alpha=0.05)
 plt.plot(x1, x1, ':', linewidth=2)
 plt.xlim([0, 1])
@@ -318,7 +318,7 @@ y1 = x1 - 0.4
 z1 = x1
 z2 = 0
 plt.figure(figsize=(12, 10))
-plt.plot(x1, y1,'r-',label='Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-Pr(A|r_i)+f(\phi_i)$')
+plt.plot(x1, y1,'r-',label=r'Truth Border of: $U_i(Pr(A|r_i),\phi_i)=-Pr(A|r_i)+f(\phi_i)$')
 plt.plot(x1, x1, ':', linewidth=2)
 plt.fill_between(x1, y1, z1, facecolor='blue', alpha=0.05, label='truth telling')
 plt.fill_between(x1, z2, y1, facecolor='green', alpha=0.05, label='lying')

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -597,7 +597,7 @@ ax.plot(wf.π_grid, cost_L1, label='choose f1')
 ax.plot(wf.π_grid, cost_L0, label='choose f0')
 ax.plot(wf.π_grid,
         np.amin(np.column_stack([h_star, cost_L0, cost_L1]),axis=1),
-        lw=15, alpha=0.1, color='b', label='$J(\pi)$')
+        lw=15, alpha=0.1, color='b', label=r'$J(\pi)$')
 
 ax.annotate(r"$\beta$", xy=(β + 0.01, 0.5), fontsize=14)
 ax.annotate(r"$\alpha$", xy=(α + 0.01, 0.5), fontsize=14)

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -204,7 +204,7 @@ axes[0].plot(grid, f1(grid), lw=2, label="$f_1$")
 axes[1].set_title("Mixtures")
 for π in 0.25, 0.5, 0.75:
     y = π * f0(grid) + (1 - π) * f1(grid)
-    axes[1].plot(y, lw=2, label=f"$\pi_k$ = {π}")
+    axes[1].plot(y, lw=2, label=rf"$\pi_k$ = {π}")
 
 for ax in axes:
     ax.legend()
@@ -606,7 +606,7 @@ plt.vlines(β, 0, β * wf.L0, linestyle="--")
 plt.vlines(α, 0, (1 - α) * wf.L1, linestyle="--")
 
 ax.set(xlim=(0, 1), ylim=(0, 0.5 * max(wf.L0, wf.L1)), ylabel="cost",
-       xlabel="$\pi$", title="Cost function $J(\pi)$")
+       xlabel=r"$\pi$", title="Cost function $J(\pi)$")
 
 plt.legend(borderpad=1.1)
 plt.show()

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -500,7 +500,7 @@ Now let's check the Gini coefficient.
 ```{code-cell} ipython3
 fig, ax = plt.subplots()
 ax.plot(μ_r_vals, gini_vals, label='gini coefficient')
-ax.set_xlabel("$\mu_r$")
+ax.set_xlabel(r"$\mu_r$")
 ax.legend()
 plt.show()
 ```

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -477,7 +477,7 @@ gini_vals = []
 for μ_r in μ_r_vals:
     wdy = WealthDynamics(μ_r=μ_r)
     gv, (f_vals, l_vals) = generate_lorenz_and_gini(wdy)
-    ax.plot(f_vals, l_vals, label=f'$\psi^*$ at $\mu_r = {μ_r:0.2}$')
+    ax.plot(f_vals, l_vals, label=fr'$\psi^*$ at $\mu_r = {μ_r:0.2}$')
     gini_vals.append(gv)
 
 ax.plot(f_vals, f_vals, label='equality')
@@ -522,7 +522,7 @@ gini_vals = []
 for σ_r in σ_r_vals:
     wdy = WealthDynamics(σ_r=σ_r)
     gv, (f_vals, l_vals) = generate_lorenz_and_gini(wdy)
-    ax.plot(f_vals, l_vals, label=f'$\psi^*$ at $\sigma_r = {σ_r:0.2}$')
+    ax.plot(f_vals, l_vals, label=fr'$\psi^*$ at $\sigma_r = {σ_r:0.2}$')
     gini_vals.append(gv)
 
 ax.plot(f_vals, f_vals, label='equality')


### PR DESCRIPTION
This PR fixes a syntax warning across the lecture series

@HumphreyYang if you have time would you mind review this PR to make sure an `r` shouldn't be an `rf` for example. It would be nice to have a double check of it. 