### PR TITLE
MAINT: update docker environment

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -7,7 +7,7 @@ jobs:
   cache:
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312-b
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.8.1-anaconda-2024-10-py312
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   preview:
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312-b
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.8.0-anaconda-2024-10-py312
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   preview:
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.8.0-anaconda-2024-10-py312
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.8.1-anaconda-2024-10-py312
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v8
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v8
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,20 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v8
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v8
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
-      # - name: Build Download Notebooks (sphinx-tojupyter)
-      #   shell: bash -l {0}
-      #   run: |
-      #     jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
-      #     mkdir -p _build/html/_notebooks
-      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Build Download Notebooks (sphinx-tojupyter)
+        shell: bash -l {0}
+        run: |
+          jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
+          mkdir -p _build/html/_notebooks
+          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       - name: Upload Execution Reports (Download Notebooks)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
           name: build-cache
           path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
-      - name: Build Download Notebooks (sphinx-tojupyter)
-        shell: bash -l {0}
-        run: |
-          jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
-          mkdir -p _build/html/_notebooks
-          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      # - name: Build Download Notebooks (sphinx-tojupyter)
+      #   shell: bash -l {0}
+      #   run: |
+      #     jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
+      #     mkdir -p _build/html/_notebooks
+      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       - name: Upload Execution Reports (Download Notebooks)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312-b
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.8.1-anaconda-2024-10-py312
       options: --gpus all
     steps:
       - name: Checkout

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -108,7 +108,7 @@ Composite Index for the period 1st January 2006 to 1st November 2019.
 ```{code-cell} python3
 import yfinance as yf
 
-s = yf.download('^IXIC', '2006-1-1', '2019-11-1', auto_adjust=True)['Adj Close']
+s = yf.download('^IXIC', '2006-1-1', '2019-11-1', auto_adjust=False)['Adj Close']
 
 r = s.pct_change()
 

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -108,7 +108,7 @@ Composite Index for the period 1st January 2006 to 1st November 2019.
 ```{code-cell} python3
 import yfinance as yf
 
-s = yf.download('^IXIC', '2006-1-1', '2019-11-1')['Adj Close']
+s = yf.download('^IXIC', '2006-1-1', '2019-11-1', auto_adjust=True)['Adj Close']
 
 r = s.pct_change()
 


### PR DESCRIPTION
This PR updates our docker container to use the latest `cuda=12.8.1`

Includes a fix for `kesten_processes` use of `yfinance`

**Note:** this is currently defaulting to `cuda=12.4` as per the in-lecture `jax` backend so will work to resolve this. 