### PR TITLE
MAINT: remove jax, pyro, torch, and gpu related software installs + GPU admonition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+          pip install pyro-ppl
           pip install --upgrade "jax[cuda12-local]"
           pip install numpyro  
           python scripts/test-jax-install.py

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -4,7 +4,7 @@ jobs:
   execution-checks:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/disk=large"
     container:
-      image: docker://us-docker.pkg.dev/colab-images/public/runtime
+      image: docker://us-docker.pkg.dev/colab-images/public/runtime:latest
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -10,6 +10,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install latest arviz
+        shell: bash -l {0}
+        run: |
+          pip install --upgrade arviz
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -10,10 +10,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install latest arviz
-        shell: bash -l {0}
-        run: |
-          pip install --upgrade arviz
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |
@@ -36,7 +32,7 @@ jobs:
       - name: Install Build Software
         shell: bash -l {0}
         run: |
-          pip install jupyter-book==0.15.1 docutils==0.17.1 quantecon-book-theme==0.7.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinx-reredirects sphinx-exercise==0.4.1 sphinxcontrib-youtube==1.1.0 sphinx-togglebutton==0.3.1 arviz==0.13.0 sphinx-proof
+          pip install jupyter-book==1.0.3 quantecon-book-theme==0.8.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinxcontrib-youtube==1.3.0 sphinx-togglebutton==0.3.2 arviz sphinx-proof sphinx-exercise sphinx-reredirects
       # Build of HTML (Execution Testing)
       - name: Build HTML
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2
+    - arviz

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,3 @@ dependencies:
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2
-    - arviz

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,4 @@ dependencies:
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2
-    # Docker Requirements
-    - pytz
-
+    - arviz

--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,0 +1,9 @@
+```{admonition} GPU
+:class: warning
+
+This lecture was built using a machine with the latest CUDA and CUDANN frameworks installed with access to a GPU.
+
+To run this lecture on [Google Colab](https://colab.research.google.com/), click on the "play" icon top right, select Colab, and set the runtime environment to include a GPU.
+
+To run this lecture on your own machine, you need to install the software listed following this notice.
+```

--- a/lectures/ar1_bayes.md
+++ b/lectures/ar1_bayes.md
@@ -17,7 +17,7 @@ kernelspec:
 ```
 
 ```{code-cell} ipython3
-:tags: [skip-execution]
+:tags: [hide-output]
 
 !pip install numpyro jax
 ```

--- a/lectures/ar1_bayes.md
+++ b/lectures/ar1_bayes.md
@@ -17,7 +17,7 @@ We'll begin with some Python imports.
 
 
 ```{code-cell} ipython3
-:tags: [hide-output]
+:tags: [hide-output, skip-execution]
 
 !pip install arviz pymc numpyro jax
 ```

--- a/lectures/ar1_bayes.md
+++ b/lectures/ar1_bayes.md
@@ -19,7 +19,15 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [skip-execution]
 
-!pip install arviz pymc numpyro jax
+!pip install numpyro jax
+```
+
+In addition to what's included in base Anaconda, we need to install the following packages
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install arviz pymc
 ```
 
 We'll begin with some Python imports.

--- a/lectures/ar1_bayes.md
+++ b/lectures/ar1_bayes.md
@@ -13,14 +13,16 @@ kernelspec:
 
 # Posterior Distributions for  AR(1) Parameters
 
-We'll begin with some Python imports.
-
+```{include} _admonition/gpu.md
+```
 
 ```{code-cell} ipython3
-:tags: [hide-output, skip-execution]
+:tags: [skip-execution]
 
 !pip install arviz pymc numpyro jax
 ```
+
+We'll begin with some Python imports.
 
 ```{code-cell} ipython3
 

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -13,6 +13,9 @@ kernelspec:
 
 # Introduction to Artificial Neural Networks
 
+```{include} _admonition/gpu.md
+```
+
 ```{code-cell} ipython3
 :tags: [skip-execution]
 

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -14,9 +14,14 @@ kernelspec:
 # Introduction to Artificial Neural Networks
 
 ```{code-cell} ipython3
-:tags: [hide-output]
+:tags: [skip-execution]
 
 !pip install --upgrade jax jaxlib kaleido
+```
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
 !conda install -y -c plotly plotly plotly-orca retrying
 ```
 

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -19,12 +19,15 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [skip-execution]
 
-!pip install --upgrade jax jaxlib kaleido
+!pip install --upgrade jax
 ```
+
+In addition to what's included in base Anaconda, we need to install the following packages
 
 ```{code-cell} ipython3
 :tags: [hide-output]
 
+!pip install kaleido
 !conda install -y -c plotly plotly plotly-orca retrying
 ```
 

--- a/lectures/bayes_nonconj.md
+++ b/lectures/bayes_nonconj.md
@@ -17,7 +17,7 @@ kernelspec:
 ```
 
 ```{code-cell} ipython3
-:tags: [skip-execution]
+:tags: [hide-output]
 
 !pip install numpyro pyro-ppl torch jax
 ```

--- a/lectures/bayes_nonconj.md
+++ b/lectures/bayes_nonconj.md
@@ -44,7 +44,7 @@ The two Python modules are
 As usual, we begin by importing some Python code.
 
 ```{code-cell} ipython3
-:tags: [hide-output]
+:tags: [hide-output, skip-execution]
 
 # install dependencies
 !pip install numpyro pyro-ppl torch jax

--- a/lectures/bayes_nonconj.md
+++ b/lectures/bayes_nonconj.md
@@ -13,6 +13,15 @@ kernelspec:
 
 # Non-Conjugate Priors
 
+```{include} _admonition/gpu.md
+```
+
+```{code-cell} ipython3
+:tags: [skip-execution]
+
+!pip install numpyro pyro-ppl torch jax
+```
+
 This lecture is a sequel to the {doc}`quantecon lecture <prob_meaning>`.
 
 That lecture offers a Bayesian interpretation of probability in a setting in which the likelihood function and the prior distribution
@@ -42,13 +51,6 @@ The two Python modules are
 - `pymc4`
 
 As usual, we begin by importing some Python code.
-
-```{code-cell} ipython3
-:tags: [hide-output, skip-execution]
-
-# install dependencies
-!pip install numpyro pyro-ppl torch jax
-```
 
 ```{code-cell} ipython3
 import numpy as np

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -15,9 +15,10 @@ kernelspec:
 # Incorrect Models
 
 In addition to what's in Anaconda, this lecture will need the following libraries:
+
 ```{code-cell} ipython
 ---
-tags: [hide-output]
+tags: [hide-output, skip-execution]
 ---
 !pip install numpyro jax
 ```

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -18,7 +18,7 @@ kernelspec:
 ```
 
 ```{code-cell} ipython
-:tags: [skip-execution]
+:tags: [hide-output]
 
 !pip install numpyro jax
 ```

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -14,12 +14,12 @@ kernelspec:
 (likelihood-ratio-process)=
 # Incorrect Models
 
-In addition to what's in Anaconda, this lecture will need the following libraries:
+```{include} _admonition/gpu.md
+```
 
 ```{code-cell} ipython
----
-tags: [hide-output, skip-execution]
----
+:tags: [skip-execution]
+
 !pip install numpyro jax
 ```
 


### PR DESCRIPTION
This PR addresses #452

~~This PR currently breaks `collab` testing. While google `collab` has `jax` it doesn't have a few other packages related to GPU such as `pyro` which is causing 1-2 lectures to fail. The installs will be listed at the top of the lecture, however a user will need to run that cell to install those packages for it to work.~~ 🤔 

I have switched these back on for local execution (this should fix `collab` while not upgrading the software for the other actions). I have documented this complexity and issue in #454 so doesn't need to be fixed here. 