### PR TITLE
[mle] Replace np.sum with @, fix typos, and use gammaln for stable Poisson log-likelihood

### DIFF
--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -868,16 +868,20 @@ class ProbitRegression:
         return norm.pdf(self.X @ self.β.T)
 
     def logL(self):
+        y = self.y
         μ = self.μ()
         return y @ np.log(μ) + (1 - y) @ np.log(1 - μ)
 
     def G(self):
+        X = self.X
+        y = self.y  
         μ = self.μ()
         ϕ = self.ϕ()
         return X.T @ (y * ϕ / μ - (1 - y) * ϕ / (1 - μ))
 
     def H(self):
         X = self.X
+        y = self.y
         β = self.β
         μ = self.μ()
         ϕ = self.ϕ()


### PR DESCRIPTION
Replace np.sum(a * b) with a @ b
https://github.com/QuantEcon/lecture-python.myst/issues/463

Fix typos in Tex

Replaced np.log(factorial(y)) with scipy.special.gammaln(y + 1) for improved numerical stability and accuracy, especially for large values of y.