### PR TITLE
[ge_arrow] Correct summation axis

### DIFF
--- a/lectures/ge_arrow.md
+++ b/lectures/ge_arrow.md
@@ -964,7 +964,7 @@ class RecurCompetitive:
     def price_risk_free_bond(self):
         "Give Q, compute price of one-period risk free bond"
 
-        PRF = np.sum(self.Q, 0)
+        PRF = np.sum(self.Q, axis=1)
         self.PRF = PRF
 
         return PRF
@@ -972,7 +972,7 @@ class RecurCompetitive:
     def risk_free_rate(self):
         "Given Q, compute one-period gross risk-free interest rate R"
 
-        R = np.sum(self.Q, 0)
+        R = np.sum(self.Q, axis=1)
         R = np.reciprocal(R)
         self.R = R
 


### PR DESCRIPTION
Hello,

Thank you for creating and maintaining this excellent lecture note. It has been very helpful for my studies.

I noticed a potential inconsistency between the theoretical definition of the risk-free rate and its implementation in the RecurCompetitive class.

The Issue:

- In the "Markov Asset Prices" section, the price of a risk-free bond in state i is defined as $R_i⁻¹ = Σ_j Q_{ij}$. This corresponds to summing the Q matrix across its rows (axis=1 in NumPy).

- The current implementation in the risk_free_bond function uses np.sum(self.Q, 0), which sums across columns (axis=0).

The Fix:

This PR corrects the summation axis from 0 to 1 to align the code with the theoretical text.

Please let me know if I have misunderstood anything.