### PR TITLE
[likelihood_bayes, mix_model] Lecture Improvements and Error Fixes

### DIFF
--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -194,6 +194,8 @@ l_arr_f = simulate(F_a, F_b, N=50000)
 l_seq_f = np.cumprod(l_arr_f, axis=1)
 ```
 
+
+
 ## Likelihood Ratio Process and Bayes’ Law
 
 Let $\pi_{t+1}$ be a Bayesian posterior probability defined as
@@ -205,7 +207,54 @@ $$ (eq:defbayesposterior)
 The likelihood ratio process is a principal actor in the formula that governs the evolution
 of the posterior probability $\pi_t$, an instance of **Bayes' Law**.
 
-Bayes' law is just the following application of the standardformula for conditional probability:
+Let's derive a couple of formulas for $\pi_{t+1}$, one in terms of likelihood ratio $l(w_t)$, the other in terms of
+$L(w^t)$.
+
+To begin, define 
+
+Let  
+
+* $f(w^{t+1}) \equiv f(w_1) f(w_2) \cdots f(w_{t+1})$
+* $g(w^{t+1}) \equiv g(w_1) g(w_2) \cdots g(w_{t+1})$
+* $\pi_0 ={\rm Prob}(q=f |{\rm no \ data})$
+* $\pi_t = {\rm Prob}(q=f |w^t)$
+
+Then 
+
+
+$$
+{\rm Prob}(w^{t+1} |{\rm no \ data}) = \pi_o f(w^{t+1})+ (1 -  \pi_0) 
+$$
+
+Probability laws connecting joint and conditional distributions imply that
+
+$$
+{\rm Prob}(q=f |w^{t+1})  {\rm Prob}(w^{t+1}  |{\rm no \ data}) = {\rm Prob}(w^{t+1} |q=f) {\rm Prob}(q=f  | {\rm no \ data})
+$$
+
+or 
+
+$$
+\pi_{t+1} [\pi_0 f(w^{t+1}) + (1- \pi_0) g(w^{t+1})] = f(w^{t+1}) \pi_0 
+$$
+
+or
+
+$$
+\pi_{t+1}  = \frac{ f(w^{t+1}) \pi_0 }{\pi_0 f(w^{t+1}) + (1- \pi_0) g(w^{t+1})}
+$$
+
+Dividing both  the numerator and the denominator on the right side of the above  equation  by $g(w^{t+1})$ implies 
+
+```{math}
+:label: eq_Bayeslaw1033
+
+\pi_{t+1}=\frac{\pi_{0}L\left(w^{t+1}\right)}{\pi_{0}L\left(w^{t+1}\right)+1-\pi_{0}} .
+```
+
+We can use a similar  line of argument to get a recursive version of formula {eq}`eq_Bayeslaw1033`.
+
+The laws of probability imply 
 
 $$
 {\rm Prob}(q=f|w^{t+1}) = \frac { {\rm Prob}(q=f|w^{t} ) f(w_{t+1})}{ {\rm Prob}(q=f|w^{t} ) f(w_{t+1}) + (1 - {\rm Prob}(q=f|w^{t} )) g(w_{t+1})}
@@ -249,81 +298,17 @@ def update(π, l):
     return π
 ```
 
-Formula {eq}`eq_recur1` can be generalized  by iterating on it and thereby deriving an
-expression for  the time $t$ posterior $\pi_{t+1}$ as a function
-of the time $0$ prior $\pi_0$ and the likelihood ratio process
-$L(w^{t+1})$ at time $t$.
 
-To begin, notice that the updating rule
+Formula {eq}`eq_Bayeslaw1033` generalizes formula {eq}`eq_recur1`.
 
-$$
-\pi_{t+1}
-=\frac{\pi_{t}\ell \left(w_{t+1}\right)}
-{\pi_{t}\ell \left(w_{t+1}\right)+\left(1-\pi_{t}\right)}
-$$
 
-implies
-
-$$
-\begin{aligned}
-\frac{1}{\pi_{t+1}}
-    &=\frac{\pi_{t}\ell \left(w_{t+1}\right)
-        +\left(1-\pi_{t}\right)}{\pi_{t}\ell \left(w_{t+1}\right)} \\
-    &=1-\frac{1}{\ell \left(w_{t+1}\right)}
-        +\frac{1}{\ell \left(w_{t+1}\right)}\frac{1}{\pi_{t}}.
-\end{aligned}
-$$
-
-$$
-\Rightarrow
-\frac{1}{\pi_{t+1}}-1
-=\frac{1}{\ell \left(w_{t+1}\right)}\left(\frac{1}{\pi_{t}}-1\right).
-$$
-
-Therefore
-
-$$
-\begin{aligned}
-    \frac{1}{\pi_{t+1}}-1
-    =\frac{1}{\prod_{i=1}^{t+1}\ell \left(w_{i}\right)}
-        \left(\frac{1}{\pi_{0}}-1\right)
-    =\frac{1}{L\left(w^{t+1}\right)}\left(\frac{1}{\pi_{0}}-1\right).
-\end{aligned}
-$$
-
-Since $\pi_{0}\in\left(0,1\right)$ and
-$L\left(w^{t+1}\right)>0$, we can verify that
-$\pi_{t+1}\in\left(0,1\right)$.
-
-After rearranging the preceding equation, we can express $\pi_{t+1}$ as a
-function of  $L\left(w^{t+1}\right)$, the  likelihood ratio process at $t+1$,
-and the initial prior $\pi_{0}$
-
-```{math}
-:label: eq_Bayeslaw103
-
-\pi_{t+1}=\frac{\pi_{0}L\left(w^{t+1}\right)}{\pi_{0}L\left(w^{t+1}\right)+1-\pi_{0}} .
-```
-
-Formula {eq}`eq_Bayeslaw103` generalizes formula {eq}`eq_recur1`.
-
-```{note}
-Fomula {eq}`eq_Bayeslaw103` can also be derived by starting from the formula for  conditional probability
-
-$$
-\pi_{t+1} \equiv {\rm Prob}(q=f|w^{t+1}) = \frac { \pi_0 f(w^{t+1})}{ \pi_0 f(w^{t+1}) + (1 - \pi_0) g(w^{t+1})}
-$$
-
-and then dividing the numerator and the denominator on the right side by $g(w^{t+1})$.
-```
-
-Formula {eq}`eq_Bayeslaw103`  can be regarded as a one step  revision of prior probability $\pi_0$ after seeing
+Formula {eq}`eq_Bayeslaw1033`  can be regarded as a one step  revision of prior probability $\pi_0$ after seeing
 the batch of data $\left\{ w_{i}\right\} _{i=1}^{t+1}$.
 
-Formula {eq}`eq_Bayeslaw103` shows the key role that the likelihood ratio process  $L\left(w^{t+1}\right)$ plays in determining
+Formula {eq}`eq_Bayeslaw1033` shows the key role that the likelihood ratio process  $L\left(w^{t+1}\right)$ plays in determining
 the posterior probability $\pi_{t+1}$.
 
-Formula {eq}`eq_Bayeslaw103` is the foundation for the insight that, because of how the likelihood ratio process behaves
+Formula {eq}`eq_Bayeslaw1033` is the foundation for the insight that, because of how the likelihood ratio process behaves
 as $t \rightarrow + \infty$, the likelihood ratio process dominates the initial prior $\pi_0$ in determining the
 limiting behavior of $\pi_t$.
 
@@ -417,7 +402,7 @@ for i in range(2):
 np.abs(π_seq - π_seq_f).max() < 1e-10
 ```
 
-We thus conclude that  the likelihood ratio process is a key ingredient of the formula {eq}`eq_Bayeslaw103` for
+We thus conclude that  the likelihood ratio process is a key ingredient of the formula {eq}`eq_Bayeslaw1033` for
 a Bayesian's posterior probabilty that nature has drawn history $w^t$ as repeated draws from density
 $f$.
 
@@ -442,7 +427,7 @@ $x \in (0,1)$
 
 
 
-Thus, the  Bayesian prior $\pi_0$ and the sequence of posterior probabilities described by equation {eq}`eq_Bayeslaw103` should **not** be interpreted as the statistician's opinion about the mixing parameter  $x$ under the alternative timing protocol in which nature draws from an $x$-mixture of $f$ and $g$.  
+Thus, the  Bayesian prior $\pi_0$ and the sequence of posterior probabilities described by equation {eq}`eq_Bayeslaw1033` should **not** be interpreted as the statistician's opinion about the mixing parameter  $x$ under the alternative timing protocol in which nature draws from an $x$-mixture of $f$ and $g$.  
 
 This is clear when we remember  the definition of $\pi_t$ in equation {eq}`eq:defbayesposterior`, which for convenience we repeat here:
 
@@ -574,7 +559,7 @@ Since $KL(m, f) < KL(m, g)$, $f$ is "closer" to the mixture distribution $m$.
 Hence by our discussion on KL divergence and likelihood ratio process in 
 {doc}`likelihood_ratio_process`, $log(L_t) \to \infty$ as $t \to \infty$.
 
-Now looking back to the key equation {eq}`eq_Bayeslaw103`. 
+Now looking back to the key equation {eq}`eq_Bayeslaw1033`. 
 
 Consider the function 
 
@@ -716,7 +701,7 @@ We can see that the posterior mean of $x$ converges to the true value $x=0.5$.
 ```{solution-end}
 ```
 
-## Behavior of  posterior probability $\{\pi_t\}$  under the subjective probability distribution
+## Behavior of  Posterior Probability $\{\pi_t\}$  Under  Subjective Probability Distribution
 
 We'll end this lecture by briefly studying what our Baysian learner expects to learn under the
 subjective beliefs $\pi_t$ cranked out by Bayes' law.

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -210,23 +210,25 @@ of the posterior probability $\pi_t$, an instance of **Bayes' Law**.
 Let's derive a couple of formulas for $\pi_{t+1}$, one in terms of likelihood ratio $l(w_t)$, the other in terms of
 $L(w^t)$.
 
-To begin, define 
+To begin, we use the notational conventions  
 
-Let  
+
 
 * $f(w^{t+1}) \equiv f(w_1) f(w_2) \cdots f(w_{t+1})$
 * $g(w^{t+1}) \equiv g(w_1) g(w_2) \cdots g(w_{t+1})$
 * $\pi_0 ={\rm Prob}(q=f |\emptyset)$
 * $\pi_t = {\rm Prob}(q=f |w^t)$
 
-Then 
+Here the symbol $\emptyset$ means "empty set" or "no data".  
+
+With no data in hand, our Bayesian statistician thinks that the probability density of the sequence $w^{t+1}$ is
 
 
 $$
 {\rm Prob}(w^{t+1} |\emptyset) = \pi_0 f(w^{t+1})+ (1 -  \pi_0)
 $$
 
-Probability laws connecting joint and conditional distributions imply that
+Probability laws connecting joint probability distributions  and conditional probability distributions imply that
 
 $$
 {\rm Prob}(q=f |w^{t+1})  {\rm Prob}(w^{t+1}  |\emptyset) = {\rm Prob}(w^{t+1} |q=f) {\rm Prob}(q=f  | \emptyset)
@@ -235,7 +237,7 @@ $$
 or 
 
 $$
-\pi_{t+1} [\pi_0 f(w^{t+1}) + (1- \pi_0) g(w^{t+1})] = f(w^{t+1}) \pi_0 
+\pi_{t+1} \left[\pi_0 f(w^{t+1}) + (1- \pi_0) g(w^{t+1})\right] = f(w^{t+1}) \pi_0 
 $$
 
 or
@@ -251,6 +253,19 @@ Dividing both  the numerator and the denominator on the right side of the above 
 
 \pi_{t+1}=\frac{\pi_{0}L\left(w^{t+1}\right)}{\pi_{0}L\left(w^{t+1}\right)+1-\pi_{0}} .
 ```
+
+
+Formula {eq}`eq_Bayeslaw1033`  can be regarded as a one step  revision of prior probability $\pi_0$ after seeing
+the batch of data $\left\{ w_{i}\right\} _{i=1}^{t+1}$.
+
+Formula {eq}`eq_Bayeslaw1033` shows the key role that the likelihood ratio process  $L\left(w^{t+1}\right)$ plays in determining
+the posterior probability $\pi_{t+1}$.
+
+Formula {eq}`eq_Bayeslaw1033` is the foundation for the insight that, because of how the likelihood ratio process behaves
+as $t \rightarrow + \infty$, the likelihood ratio process dominates the initial prior $\pi_0$ in determining the
+limiting behavior of $\pi_t$.
+
+### A recursive formula
 
 We can use a similar  line of argument to get a recursive version of formula {eq}`eq_Bayeslaw1033`.
 
@@ -284,6 +299,8 @@ Dividing both  the numerator and the denominator on the right side of the  equat
 with $\pi_{0}$ being a Bayesian prior probability that $q = f$,
 i.e., a personal or subjective belief about $q$ based on our having seen no data.
 
+Formula {eq}`eq_Bayeslaw1033`  can be deduced by iterating on equation {eq}`eq_recur1`. 
+
 Below we define a Python function that updates belief $\pi$ using
 likelihood ratio $\ell$ according to  recursion {eq}`eq_recur1`
 
@@ -298,19 +315,11 @@ def update(π, l):
     return π
 ```
 
+As mentioned above, formula {eq}`eq_Bayeslaw1033` shows the key role that the likelihood ratio process  $L\left(w^{t+1}\right)$ plays in determining the posterior probability $\pi_{t+1}$.
 
-Formula {eq}`eq_Bayeslaw1033` generalizes formula {eq}`eq_recur1`.
-
-
-Formula {eq}`eq_Bayeslaw1033`  can be regarded as a one step  revision of prior probability $\pi_0$ after seeing
-the batch of data $\left\{ w_{i}\right\} _{i=1}^{t+1}$.
-
-Formula {eq}`eq_Bayeslaw1033` shows the key role that the likelihood ratio process  $L\left(w^{t+1}\right)$ plays in determining
-the posterior probability $\pi_{t+1}$.
-
-Formula {eq}`eq_Bayeslaw1033` is the foundation for the insight that, because of how the likelihood ratio process behaves
-as $t \rightarrow + \infty$, the likelihood ratio process dominates the initial prior $\pi_0$ in determining the
+As $t \rightarrow + \infty$, the likelihood ratio process dominates the initial prior $\pi_0$ in determining the
 limiting behavior of $\pi_t$.
+
 
 To illustrate this insight, below we will plot  graphs showing **one** simulated
 path of the  likelihood ratio process $L_t$ along with two paths of

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -2139,3 +2139,136 @@ and as applied in {doc}`odu`.
 
 Likelihood ratio processes appear again in {doc}`advanced:additive_functionals`, which contains another illustration
 of the **peculiar property** of likelihood ratio processes described above.
+
+
+## Exercises
+
+```{exercise}
+:label: lr_ex1
+
+Consider the setting where nature generates data from a third density $h$. 
+
+Let $\{w_t\}_{t=1}^T$ be IID draws from $h$, and let $L_t = L(w^t)$ be the likelihood ratio process defined as in the lecture.
+
+Show that:
+
+$$
+\frac{1}{t} E_h[\log L_t] = K_g - K_f
+$$
+
+with finite $K_g, K_f < \infty$, $E_h |\log f(W)| < \infty$ and $E_h |\log g(W)| < \infty$.
+
+*Hint:* Start by expressing $\log L_t$ as a sum of $\log \ell(w_i)$ terms and compare with the definition of $K_f$ and $K_g$.
+```
+
+```{solution-start} lr_ex1
+:class: dropdown
+```
+
+Since $w_1, \ldots, w_t$ are IID draws from $h$, we can write
+
+$$
+\log L_t = \log \prod_{i=1}^t \ell(w_i) = \sum_{i=1}^t \log \ell(w_i) = \sum_{i=1}^t \log \frac{f(w_i)}{g(w_i)}
+$$
+
+Taking the expectation under $h$
+
+$$
+E_h[\log L_t] 
+= E_h\left[\sum_{i=1}^t \log \frac{f(w_i)}{g(w_i)}\right] 
+= \sum_{i=1}^t E_h\left[\log \frac{f(w_i)}{g(w_i)}\right]
+$$
+
+Since the $w_i$ are identically distributed
+
+$$
+E_h[\log L_t] = t \cdot E_h\left[\log \frac{f(w)}{g(w)}\right]
+$$
+
+where $w \sim h$.
+
+Therefore
+
+$$
+\frac{1}{t} E_h[\log L_t] = E_h\left[\log \frac{f(w)}{g(w)}\right] = E_h[\log f(w)] - E_h[\log g(w)]
+$$
+
+Now, from the definition of Kullback-Leibler divergence
+
+$$
+K_f = KL(h, f) = \int h(w) \log \frac{h(w)}{f(w)} dw = E_h[\log h(w)] - E_h[\log f(w)]
+$$
+
+This gives us
+
+$$
+E_h[\log f(w)] = E_h[\log h(w)] - K_f
+$$
+
+Similarly
+
+$$
+E_h[\log g(w)] = E_h[\log h(w)] - K_g
+$$
+
+Substituting back
+
+$$
+\begin{aligned}
+\frac{1}{t} E_h[\log L_t] &= E_h[\log f(w)] - E_h[\log g(w)] \\
+&= [E_h[\log h(w)] - K_f] - [E_h[\log h(w)] - K_g] \\
+&= K_g - K_f
+\end{aligned}
+$$
+
+```{solution-end}
+```
+
+```{exercise}
+:label: lr_ex2
+
+Building on {ref}`lr_ex1`, use the result to explain what happens to $L_t$ as $t \to \infty$ in the following cases:
+
+1. When $K_g > K_f$ (i.e., $f$ is "closer" to $h$ than $g$ is)
+2. When $K_g < K_f$ (i.e., $g$ is "closer" to $h$ than $f$ is)
+
+Relate your answer to the simulation results shown in the {ref}`Kullback-Leibler Divergence <rel_entropy>` section.
+```
+
+```{solution-start} lr_ex2
+:class: dropdown
+```
+
+From {ref}`lr_ex1`, we know that:
+
+$$
+\frac{1}{t} E_h[\log L_t] = K_g - K_f
+$$
+
+**Case 1:** When $K_g > K_f$ 
+
+Here, $f$ is "closer" to $h$ than $g$ is. Since $K_g - K_f > 0$
+
+$$
+E_h[\log L_t] = t \cdot (K_g - K_f) \to +\infty \text{ as } t \to \infty
+$$
+
+By the Law of Large Numbers, $\frac{1}{t} \log L_t \to K_g - K_f > 0$ almost surely.
+
+Therefore $L_t \to +\infty$ almost surely.
+
+**Case 2:** When $K_g < K_f$
+
+Here, $g$ is "closer" to $h$ than $f$ is. Since $K_g - K_f < 0$
+
+$$
+E_h[\log L_t] = t \cdot (K_g - K_f) \to -\infty \text{ as } t \to \infty
+$$
+
+Therefore by similar reasoning $L_t \to 0$ almost surely.
+
+```{solution-end}
+```
+
+
+

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -1464,7 +1464,7 @@ def protocol_2(π_minus_1, T, N=1000):
     return sequences, true_models_F
 ```
 
-**Remark:** Under timing protocol 2, the $\{w_t\}_{t=1}^T$ is a sequence of IID draws from $h(w)$. Under timing protocol 1, the the $\{w_t\}_{t=1}^T$ is 
+**Remark:** Under timing protocol 2, the $\{w_t\}_{t=1}^T$ is a sequence of IID draws from $h(w)$. Under timing protocol 1, the $\{w_t\}_{t=1}^T$ is 
 not IID.  It is **conditionally IID** -- meaning that with probability $\pi_{-1}$ it is a sequence of IID draws from $f(w)$ and with probability $1-\pi_{-1}$ it is a sequence of IID draws from $g(w)$. For more about this, see {doc}`this lecture about exchangeability <exchangeable>`.
 
 We  again deploy a **likelihood ratio process** with time $t$ component being the likelihood ratio  

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -449,7 +449,7 @@ def plot_π_seq(α, π1=0.2, π2=0.8, T=200):
     ax1.set_ylabel(r"$\pi_t$")
     ax1.set_xlabel("t")
     ax1.legend()
-    ax1.set_title("when $\\alpha F + (1-\\alpha)G$ F governs data")
+    ax1.set_title("when $\\alpha F + (1-\\alpha)G$ governs data")
 
     ax2 = ax1.twinx()
     ax2.plot(range(1, T+1), np.log(l_seq_mixed[0, :]), '--', color='b')
@@ -601,7 +601,10 @@ ax.set_xlabel(r'$\alpha$')
 # plot KL
 ax2 = ax.twinx()
 # plot limit point
-ax2.scatter(α_arr_x, π_lim_arr, facecolors='none', edgecolors='tab:blue', label=r'$\pi$ lim')
+ax2.scatter(α_arr_x, π_lim_arr, 
+            facecolors='none', 
+            edgecolors='tab:blue', 
+            label=r'$\pi$ lim')
 ax2.set_ylabel('π lim')
 
 ax.legend(loc=[0.85, 0.8])

--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -18,7 +18,7 @@ kernelspec:
 ```
 
 ```{code-cell} ipython3
-:tags: [no-execute]
+:tags: [no-execute, hide-output]
 
 !pip install numpyro jax
 ```

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -39,15 +39,14 @@ Friedman and W. Allen Wallis during World War II when they were analysts at the 
 This problem led Abraham Wald {cite}`Wald47` to formulate **sequential analysis**,
 an approach to statistical decision problems that is  intimately related to dynamic programming.
 
-In the spirit of {doc}`this earlier lecture <prob_meaning>`, the present lecture and its {doc}`sequel <wald_friedman_2>` approach the problem from two distinct points of view.
+In the spirit of {doc}`this earlier lecture <prob_meaning>`, the present lecture and its {doc}`sequel <wald_friedman_2>` approach the problem from two distinct points of view, one frequentist, the other Bayesian. 
 
 In this lecture, we describe  Wald's formulation of the problem from the perspective of a  statistician
 working within the Neyman-Pearson tradition of a frequentist statistician who thinks about testing  hypotheses and consequently  use  laws of large numbers to  investigate limiting properties of particular statistics under a given  **hypothesis**, i.e., a vector of **parameters** that pins down a  particular member of a manifold of statistical models that interest the statistician.   
 
   * From {doc}`this earlier lecture on frequentist and bayesian statistics<prob_meaning>`, please remember that a  frequentist statistician routinely calculates functions of sequences of random variables, conditioning on a vector of parameters.
 
-In {doc}`this sequel <wald_friedman_2>` we'll discuss another formulation that adopts   the perspective of a **Bayesian statistician** who views 
-parameter vectors as vectors of random variables that are jointly distributed with  observable variables that he is concerned about.
+In {doc}`this sequel <wald_friedman_2>` we'll discuss another formulation that adopts   the perspective of a **Bayesian statistician** who views parameters as vectors of random variables that are jointly distributed with  observable variables that he is concerned about.
 
 Because we are taking a frequentist perspective that is concerned about relative frequencies conditioned on alternative parameter values, i.e., 
 alternative **hypotheses**, key ideas in this lecture
@@ -55,12 +54,12 @@ alternative **hypotheses**, key ideas in this lecture
 - Type I and type II statistical errors
     - a type I error occurs when you reject a null hypothesis that is true
     - a type II error occures when you accept a null hypothesis that is false
-- Abraham Wald's **sequential probability ratio test**
 - The **power** of a frequentist statistical test
 - The **size** of a frequentist statistical test 
 - The **critical region** of a statistical test
 - A **uniformly most powerful test**
 - The role of a Law of Large Numbers (LLN) in interpreting **power** and **size** of a frequentist statistical test
+- Abraham Wald's **sequential probability ratio test**
 
 We'll begin with some imports:
 
@@ -119,7 +118,7 @@ Let's listen to Milton Friedman tell us what happened
 > $\ldots$.
 
 Friedman and Wallis worked on  the problem but, after realizing that
-they were not able to solve it,  they described the problem to  Abraham Wald.
+they were not able to solve it,  they told Abraham Wald about the problem.
 
 That started Wald on the path that led him  to *Sequential Analysis* {cite}`Wald47`.
 
@@ -236,7 +235,7 @@ Wald notes that
 > one critical region $W$ is more desirable than another if it
 > has smaller values of $\alpha$ and $\beta$. Although
 > either $\alpha$ or $\beta$ can be made arbitrarily small
-> by a proper choice of the critical region $W$, it is possible
+> by a proper choice of the critical region $W$, it is impossible
 > to make both $\alpha$ and $\beta$ arbitrarily small for a
 > fixed value of $n$, i.e., a fixed sample size.
 
@@ -333,10 +332,9 @@ random variables is also independently and identically distributed (IID).
 
 But the observer does not know which of the two distributions generated the sequence.
 
-For reasons explained in  [Exchangeability and Bayesian Updating](https://python.quantecon.org/exchangeable.html), this means that the sequence is not
-IID.
+For reasons explained in  [Exchangeability and Bayesian Updating](https://python.quantecon.org/exchangeable.html), this means that the observer thinks that  sequence is not IID.
 
-The observer has something to learn, namely, whether the observations are drawn from  $f_0$ or from $f_1$.
+Consequently, the observer has something to learn, namely, whether the observations are drawn from  $f_0$ or from $f_1$.
 
 The decision maker   wants  to decide which of the  two distributions is generating outcomes.
 
@@ -356,12 +354,12 @@ To repeat ourselves
 
 ### Choices
 
-After observing $z_k, z_{k-1}, \ldots, z_0$, the decision-maker
+After observing $z_k, z_{k-1}, \ldots, z_1$, the decision-maker
 chooses among three distinct actions:
 
 - He decides that $f = f_0$ and draws no more $z$'s
 - He decides that $f = f_1$ and draws no more $z$'s
-- He postpones deciding now and instead chooses to draw a
+- He postpones deciding  and instead chooses to draw 
   $z_{k+1}$
 
 
@@ -369,8 +367,8 @@ Wald proceeds as follows.
 
 He defines
 
-- $p_{0m} = f_0(z_0) \cdots f_0(z_m)$
-- $p_{1m} = f_1(z_0) \cdots f_1(z_m)$
+- $p_{0m} = f_0(z_1) \cdots f_0(z_m)$
+- $p_{1m} = f_1(z_1) \cdots f_1(z_m)$
 - $L_{m} = \frac{p_{1m}}{p_{0m}}$
 
 Here $\{L_m\}_{m=0}^\infty$ is a **likelihood ratio process**.
@@ -477,11 +475,11 @@ Below is the algorithm for the simulation.
    for each distribution, compute the empirical type I error $\hat{\alpha}$ and type II error $\hat{\beta}$ with
 
 $$
-\hat{\alpha} = \frac{\text{\# of times reject } H_0 \text{ when } f_0 \text{ is true}}{\text{\# of replications with } f_0 \text{ true}}
+\hat{\alpha} = \frac{\text{$\#$ of times reject } H_0 \text{ when } f_0 \text{ is true}}{\text{$\#$ of replications with } f_0 \text{ true}}
 $$
 
 $$
-\hat{\beta} = \frac{\text{\# of times accept } H_0 \text{ when } f_1 \text{ is true}}{\text{\# of replications with } f_1 \text{ true}}
+\hat{\beta} = \frac{\text{$\#$ of times accept } H_0 \text{ when } f_1 \text{ is true}}{\text{$\#$ of replications with } f_1 \text{ true}}
 $$
 
 ```{code-cell} ipython3
@@ -1079,4 +1077,4 @@ We'll dig deeper into some of the ideas used here in the following earlier and l
 * The concept of **exchangeability**, which underlies much of statistical learning, is explored in depth in our {doc}`lecture on exchangeable random variables <exchangeable>`.
 * For a deeper understanding of likelihood ratio processes and their role in frequentist and Bayesian statistical theories, see {doc}`likelihood_ratio_process`.
 * Building on that foundation, {doc}`likelihood_bayes` examines the role of likelihood ratio processes in **Bayesian learning**.
-* Finally, {doc}`this later lecture <navy_captain>` revisits the subject discussed here and examines whether the frequentist decision rule that the Navy ordered the captain to use would perform better or worse than the sequential decision rule we've developed.
+* Finally, {doc}`this later lecture <navy_captain>` revisits the subject discussed here and examines whether the frequentist decision rule that the Navy ordered the captain to use would perform better or worse than Abraham Wald's sequential decision rule.


### PR DESCRIPTION
This PR includes improvements Tom made to the lectures on likelihood ratio processes.

This PR addresses #500 and fix a major bug in `mix_model`.