### PR TITLE
[FIX] Remove Syntax Warning from Cache Rebuild

### DIFF
--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -857,7 +857,7 @@ T_arr = [250, 150, 75, 50]
 fix, axs = plt.subplots(2, 3, figsize=(13, 6))
 titles = ['Arrow-Hicks Prices', 'Labor Rental Rate', 'Capital Rental Rate',
           'Consumption', 'Capital', 'Lagrange Multiplier']
-ylabels = ['$q_t^0$', '$w_t$', '$\eta_t$', '$c_t$', '$k_t$', '$\mu_t$']
+ylabels = ['$q_t^0$', '$w_t$', r'$\eta_t$', '$c_t$', '$k_t$', r'$\mu_t$']
 
 for T in T_arr:
     c_path, k_path = bisection(pp, 0.3, k_ss/3, T, verbose=False)
@@ -905,7 +905,7 @@ for γ in γ_arr:
     paths = [q_path, w_path, η_path, c_path, k_path, μ_path]
 
     for i, ax in enumerate(axs.flatten()):
-        ax.plot(paths[i], label=f'$\gamma = {γ}$')
+        ax.plot(paths[i], label=fr'$\gamma = {γ}$')
         ax.set(title=titles[i], ylabel=ylabels[i], xlabel='t')
         if titles[i] == 'Capital':
             ax.axhline(k_ss, lw=1, ls='--', c='k')

--- a/lectures/coleman_policy_iter.md
+++ b/lectures/coleman_policy_iter.md
@@ -347,7 +347,7 @@ n = 15
 σ = grid.copy()  # Set initial condition
 
 fig, ax = plt.subplots()
-lb = 'initial condition $\sigma(y) = y$'
+lb = r'initial condition $\sigma(y) = y$'
 ax.plot(grid, σ, color=plt.cm.jet(0), alpha=0.6, label=lb)
 
 for i in range(n):

--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -481,7 +481,7 @@ def learning_example(F_a=1, F_b=1, G_a=3, G_b=1.2):
     ax3.fill_between(π_grid, roots[0], roots[1], color='green', alpha=0.15)
     ax3.fill_between(π_grid, roots[1], w_max, color='blue', alpha=0.15)
     ax3.hlines(roots, 0., 1., linestyle="--")
-    ax3.set(xlabel='$\pi$', ylabel='$w$')
+    ax3.set(xlabel=r'$\pi$', ylabel='$w$')
     ax3.grid()
 
     plt.show()
@@ -694,8 +694,8 @@ def expected_ratio(F_a=1, F_b=1, G_a=3, G_b=1.2):
         plt.plot(π_grid, expected_rario, label=f"{q} generates")
 
     plt.hlines(1, 0, 1, linestyle="--")
-    plt.xlabel("$π_t$")
-    plt.ylabel("$E[\pi_{t+1}/\pi_t]$")
+    plt.xlabel(r"$\pi_t$")
+    plt.ylabel(r"$E[\pi_{t+1}/\pi_t]$")
     plt.legend()
 
     plt.show()

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -532,8 +532,8 @@ def xbar(ϕ):
 
 ϕ_grid = np.linspace(0, 1, 100)
 fig, ax = plt.subplots(figsize=(9, 7))
-ax.set(xlabel='$\phi$')
-ax.plot(ϕ_grid, [xbar(ϕ) * (1 - ϕ) for ϕ in ϕ_grid], label='$w^*(\phi)$')
+ax.set(xlabel=r'$\phi$')
+ax.plot(ϕ_grid, [xbar(ϕ) * (1 - ϕ) for ϕ in ϕ_grid], label=r'$w^*(\phi)$')
 ax.legend()
 
 plt.show()

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -257,7 +257,7 @@ class LakeModel:
 
 
     def rate_steady_state(self, tol=1e-6):
-        """
+        r"""
         Finds the steady state of the system :math:`x_{t+1} = \hat A x_{t}`
 
         Returns
@@ -1005,7 +1005,7 @@ class LakeModelModified:
 
 
     def rate_steady_state(self, tol=1e-6):
-        """
+        r"""
         Finds the steady state of the system :math:`x_{t+1} = \hat A x_{t}`
 
         Returns

--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -1605,7 +1605,7 @@ ax.set(xlabel='Time', xlim=(0, max(time)))
 ax.plot(time, q_bar, 'k-', lw=2, alpha=0.6, label=r'$\bar q_t$')
 ax.plot(time, q, 'b-', lw=2, alpha=0.6, label='$q_t$')
 ax.legend(ncol=2, **legend_args)
-s = f'dynamics with $\gamma = {γ}$'
+s = fr'dynamics with $\gamma = {γ}$'
 ax.text(max(time) * 0.6, 1 * q_bar.max(), s, fontsize=14)
 plt.show()
 ```

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -780,7 +780,7 @@ plt.fill_between(range(1, n+1), μθ_hat_lower, μθ_hat_higher,
                  color='b', alpha=0.2, label='95%')
 
 plt.xlabel('number of test scores')
-plt.ylabel('$\hat{θ}$')
+plt.ylabel(r'$\hat{θ}$')
 plt.legend()
 
 plt.show()
@@ -2225,7 +2225,7 @@ Below we’ll plot several things
 
 ```{code-cell} python3
 plt.scatter(range(N), y, label='y')
-plt.scatter(range(N), ε, label='$\epsilon$')
+plt.scatter(range(N), ε, label=r'$\epsilon$')
 plt.hlines(f[0], 0, N//2-1, ls='--', label='$f_{1}$')
 plt.hlines(f[1], N//2, N-1, ls='-.', label='$f_{2}$')
 plt.legend()

--- a/lectures/svd_intro.md
+++ b/lectures/svd_intro.md
@@ -974,7 +974,7 @@ def compare_pca_svd(da):
     axs[0].set_title('ε')
     axs[0].set_xlabel('n')
     axs[1].plot(da.VT[:da.r, :].T * np.sqrt(da.λ))
-    axs[1].set_title('$V^\top *\sqrt{\lambda}$')
+    axs[1].set_title(r'$V^\top *\sqrt{\lambda}$')
     axs[1].set_xlabel('n')
     plt.show()
 ```

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -921,7 +921,7 @@ fig.suptitle(r'The function $V(M(\gamma))$', fontsize=16)
 for ax, grid, N, i in zip(axes, (value_ex1_grid, value_ex2_grid),
                           (n1, n2), (1, 2)):
     ax.plot(γ_grid, grid)
-    ax.set(title=f'Example {i}', xlabel='$\gamma$')
+    ax.set(title=f'Example {i}', xlabel=r'$\gamma$')
     ax.axhline(0, c='k', lw=1)
     ax.axvline(N.bounds()[0], c='r', ls='--', label='lower bound')
     ax.axvline(N.bounds()[1], c='g', ls='--', label='upper bound')


### PR DESCRIPTION
This PR removes `SyntaxWarning` that appears after the cache rebuild.