### PR TITLE
[von_neumann_model] lecture improvements

### DIFF
--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -61,7 +61,6 @@ np.set_printoptions(precision=2)
 The code below provides the `Neumann` class
 
 ```{code-cell} ipython3
-:tags: [collapse-20]
 
 class Neumann:
 

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -19,14 +19,6 @@ kernelspec:
         </a>
 </div>
 
-<style>
-/* Only expand code cells on this page */
-div.cell div.highlight,
-div.cell div.output_scroll {
-    max-height: none !important;
-    overflow-y: visible !important;
-}
-</style>
 ```
 
 ```{index} single: python
@@ -93,9 +85,9 @@ class Neumann:
         Ap - the cost of each activity
 
     Both A and B have non-negative entries. Moreover, we assume that
-    (1) Assumption 1 (every good which is consumed is also produced):
+    (1) Assumption I (every good which is consumed is also produced):
         for all j, b_{.,j} > 0, i.e. at least one entry is strictly positive
-    (2) Assumption 2 (no free lunch):
+    (2) Assumption II (no free lunch):
         for all i, a_{i,.} > 0, i.e. at least one entry is strictly positive
 
     Parameters
@@ -139,9 +131,9 @@ class Neumann:
           - number of goods          : {n}
           - number of activities     : {m}
 
-        Assumptions:// TODO:change {AI} variable into A1?
-          - A1:  every column of B has a positive entry    : {AI} 
-          - A2: every row of A has a positive entry       : {AII}
+        Assumptions://
+          - AI:  every column of B has a positive entry    : {AI} 
+          - AII: every row of A has a positive entry       : {AII}
 
         """
         # Irreducible                                       : {irr}
@@ -382,7 +374,7 @@ an economy.
 
 Two key assumptions restrict economy $(A,B)$:
 
-````{prf:assumption} every good that is consumed is also produced)
+````{prf:assumption} every good that is consumed is also produced
 :label: assumption1
 
 ```{math}

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -109,13 +109,13 @@ class Neumann:
         assert (self.A >= 0).all() and (self.B >= 0).all(), 'The input and \
               output matrices must have only non-negative entries!'
 
-        # (1) Check whether Assumption 1 is satisfied:
+        # (1) Check whether Assumption I is satisfied:
         if (np.sum(B, 0) <= 0).any():
             self.AI = False
         else:
             self.AI = True
 
-        # (2) Check whether Assumption 2 is satisfied:
+        # (2) Check whether Assumption II is satisfied:
         if (np.sum(A, 1) <= 0).any():
             self.AII = False
         else:
@@ -328,13 +328,13 @@ We use the following notation.
 $\mathbf{0}$ denotes
 a vector of zeros.
 
-We call an $n$-vector  positive and write
+We call an $n$-vector **positive** and write
 $x\gg \mathbf{0}$ if $x_i>0$ for all $i=1,2,\dots,n$.
 
-We call a vector  non-negative and write $x\geq \mathbf{0}$ if $x_i\geq 0$ for
+We call a vector **non-negative** and write $x\geq \mathbf{0}$ if $x_i\geq 0$ for
 all $i=1,2,\dots,n$.
 
-We call a vector  semi-positive and written $x > \mathbf{0}$ if
+We call a vector **semi-positive** and written $x > \mathbf{0}$ if
 $x\geq \mathbf{0}$ and $x\neq \mathbf{0}$.
 
 For two conformable vectors $x$ and $y$, $x\gg y$,
@@ -389,18 +389,18 @@ Two key assumptions restrict economy $(A,B)$:
 ```
 ````
 
-A semi-positive  *intensity* $m$-vector  $x$ denotes  levels at which
+A semi-positive *intensity* $m$-vector $x$ denotes levels at which
 activities are operated.
 
 Therefore,
 
-- vector $x^TA$ gives the total amount of *goods used in
+- vector $x^T A$ gives the total amount of *goods used in
   production*
-- vector $x^TB$ gives *total outputs*
+- vector $x^T B$ gives *total outputs*
 
 An economy $(A,B)$ is said to be *productive*, if there exists a
 non-negative intensity vector $x \geq 0$ such
-that $x^T B > x^TA$.
+that $x^T B > x^T A$.
 
 The semi-positive $n$-vector $p$ contains prices assigned to
 the $n$ goods.
@@ -412,21 +412,24 @@ The $p$ vector implies *cost* and *revenue* vectors
 
 Satisfaction or a property of an input-output pair $(A,B)$ called *irreducibility*
 (or indecomposability) determines whether an economy can be decomposed
-into multiple     "sub-economies".
+into multiple "sub-economies".
 
 ```{prf:definition}
 For an economy $(A,B)$, the set of goods
-$S\subset \{1,2,\dots,n\}$ is called an *independent subset* if
+$S\subset \{1,2,\dots,n\}$ is called an **independent subset** if
 it is possible to produce every good in $S$ without consuming
-goods from outside $S$. Formally, the set $S$ is independent if
+goods from outside $S$.
+
+Formally, the set $S$ is independent if
 $\exists T\subset \{1,2,\dots,m\}$ (a subset of activities) such
-that $a_{i,j}=0$ $\forall i\in T$ and $j\in S^c$ and
-for all $j\in S$, $\exists i\in T$ for which  $b_{i,j}>0$.
+that $a_{i,j}=0$, $\forall i\in T$ and $j\in S^c$ and
+for all $j\in S$, $\exists i\in T$ for which $b_{i,j}>0$.
+
 The economy is **irreducible** if there are no proper independent
 subsets.
 ```
 
-We study two examples, both in  Chapter 9.6 of Gale {cite}`gale1989theory`
+We study two examples, both in Chapter 9.6 of Gale {cite}`gale1989theory`
 
 ```{code-cell} ipython3
 # (1) Irreducible (A, B) example: α_0 = β_0
@@ -511,7 +514,7 @@ We follow John von Neumann in studying “balanced growth”.
 Let $./$ denote an elementwise division of one vector by another and let
 $\alpha >0$ be a scalar.
 
-Then *balanced growth* is a situation in which
+Then **balanced growth** is a situation in which
 
 $$
 x_{t+1}./x_t = \alpha , \quad \forall t \geq 0
@@ -553,10 +556,9 @@ relationship between  technological and valuation characteristics of
 the economy:
 
 ```{prf:definition}
-The *technological expansion problem* (TEP) for the economy
+The **technological expansion problem** (TEP) for the economy
 $(A,B)$ is to find a semi-positive $m$-vector $x>0$
 and a number $\alpha\in\mathbb{R}$ that satisfy
-```
 
 $$
 \begin{aligned}
@@ -564,6 +566,7 @@ $$
     &\text{s.t. }\hspace{2mm}x^T B \geq \alpha x^T A
     \end{aligned}
 $$
+```
 
 Theorem 9.3 of David Gale’s book {cite}`gale1989theory` asserts that if {prf:ref}`assumption1` and {prf:ref}`assumption2` are
 both satisfied, then a maximum value of $\alpha$ exists and that it is
@@ -596,7 +599,7 @@ and the *economical expansion problem* are both linearly homogeneous,
 the optimality of $x_0$ and $p_0$ are defined only up to a
 positive scale factor.
 
-For convenience (and to emphasize a close connection to zero-sum games),  we normalize both vectors
+For convenience (and to emphasize a close connection to zero-sum games), we normalize both vectors
 $x_0$ and $p_0$ to have unit length.
 
 A standard duality argument (see Lemma 9.4. in (Gale, 1960) {cite}`gale1989theory`) implies
@@ -628,14 +631,20 @@ $$
 ```
 
 ```{prf:proof} (Sketch)
+
 {prf:ref}`assumption1` and {prf:ref}`assumption2` imply that there exist $(\alpha_0,
-x_0)$ and $(\beta_0, p_0)$ that solve the TEP and EEP, respectively. If
-$\gamma^*>\alpha_0$, then by definition of $\alpha_0$, there cannot
+x_0)$ and $(\beta_0, p_0)$ that solve the TEP and EEP, respectively. 
+
+If $\gamma^*>\alpha_0$, then by definition of $\alpha_0$, there cannot
 exist a semi-positive $x$ that satisfies $x^T B \geq \gamma^{* }
-x^T A$.  Similarly, if $\gamma^*<\beta_0$, there is no semi-positive
+x^T A$.
+
+Similarly, if $\gamma^*<\beta_0$, there is no semi-positive
 $p$ for which $Bp \leq \gamma^{* } Ap$. Let $\gamma^{*
 }\in[\beta_0, \alpha_0]$, then $x_0^T B \geq \alpha_0 x_0^T A \geq
-\gamma^{* } x_0^T A$.  Moreover, $Bp_0\leq \beta_0 A p_0\leq \gamma^* A
+\gamma^{* } x_0^T A$.
+
+Moreover, $Bp_0\leq \beta_0 A p_0\leq \gamma^* A
 p_0$. These two inequalities imply $x_0\left(B - \gamma^{* } A\right)p_0
 = 0$.
 ```
@@ -655,7 +664,7 @@ be unused.
 
 Therefore, the conditions stated in {prf:ref}`theorem1` ex encode all equilibrium conditions.
 
-So  {prf:ref}`theorem1` essentially states that under {prf:ref}`assumption1` and {prf:ref}`assumption2` there
+So {prf:ref}`theorem1` essentially states that under {prf:ref}`assumption1` and {prf:ref}`assumption2` there 
 always exists an equilibrium $\left(\gamma^{*}, x_0, p_0\right)$
 with balanced growth.
 
@@ -682,6 +691,7 @@ To compute the equilibrium $(\gamma^{*}, x_0, p_0)$, we follow the
 algorithm proposed by Hamburger, Thompson and Weil (1967), building on
 the key insight that an equilibrium (with balanced growth) can be
 solves a particular two-player zero-sum game.
+
 First, we introduce some notation.
 
 Consider the $m\times n$ matrix $C$ as a payoff matrix,
@@ -689,7 +699,7 @@ with the entries representing payoffs from the **minimizing** column
 player to the **maximizing** row player and assume that the players can
 use mixed strategies. Thus,
 
-* the  row player chooses the $m$-vector $x > \mathbf{0}$ subject to $\iota_m^T x = 1$
+* the row player chooses the $m$-vector $x > \mathbf{0}$ subject to $\iota_m^T x = 1$
 * the column player chooses the $n$-vector $p > \mathbf{0}$ subject to $\iota_n^T p = 1$.
 
 ```{prf:definition}
@@ -703,7 +713,7 @@ $$
 \end{aligned}
 $$
 
-The number $V(C)$ is called the *value* of the game.
+The number $V(C)$ is called the **value** of the game.
 ```
 
 From the above definition, it is clear that the value $V(C)$ has
@@ -729,10 +739,9 @@ $$
 
 ### Connection with Linear Programming (LP)
 
-Nash equilibria of a finite two-player zero-sum game solve  a linear programming problem.
+Nash equilibria of a finite two-player zero-sum game solve a linear programming problem.
 
-To see this, we introduce
-the following notation
+To see this, we introduce the following notation
 
 * For a fixed $x$, let $v$ be the value of the minimization problem: $v \equiv \min_p x^T C p = \min_j x^T C e^j$
 * For a fixed $p$, let $u$ be the value of the maximization problem: $u \equiv \max_x x^T C p = \max_i (e^i)^T C p$
@@ -776,6 +785,7 @@ $x_0^T B \gg \mathbf{0}$, where $x_0$ is a maximizing
 vector. Since $B$ is non-negative, this requires that each
 column of $B$ has at least one positive entry, which is
 {prf:ref}`assumption1`.
+
 * $\Leftarrow$ From {prf:ref}`assumption1` and the fact
 that $p>\mathbf{0}$, it follows that $Bp > \mathbf{0}$.
 This implies that the maximizing player can always choose $x$
@@ -797,9 +807,11 @@ calculating the solution of the game implies
   $\exists j\in\{1, \dots, n\}$, s.t.
   $[x^T M(\gamma)]_j < 0$ implying
   that $V(M(\gamma)) < 0$.
+
 - If $\gamma < \beta_0$, then for all $p>0$, there
   $\exists i\in\{1, \dots, m\}$, s.t.
   $[M(\gamma)p]_i > 0$ implying that $V(M(\gamma)) > 0$.
+  
 - If $\gamma \in \{\beta_0, \alpha_0\}$, then (by {prf:ref}`theorem1`) the
   optimal intensity and price vectors $x_0$ and $p_0$
   satisfy
@@ -897,6 +909,7 @@ Compute $\alpha_0$ and $\beta_0$
     1. If $V(M(\gamma)) \geq 0$, then set $LB = \gamma$,
        otherwise let $UB = \gamma$.
     1. Iterate on 1. and 2. until $|UB - LB| < \epsilon$.
+
 - Finding $\beta_0$
     1. Fix $\gamma = \frac{UB + LB}{2}$ and compute the solution
        of the two-player zero-sum game associated.
@@ -905,6 +918,7 @@ Compute $\alpha_0$ and $\beta_0$
     1. If $V(M(\gamma)) > 0$, then set $LB = \gamma$,
        otherwise let $UB = \gamma$.
     1. Iterate on 1. and 2. until $|UB - LB| < \epsilon$.
+
 - *Existence*: Since $V(M(LB))>0$ and $V(M(UB))<0$ and
   $V(M(\cdot))$ is a continuous, nonincreasing function, there is
   at least one $\gamma\in[LB, UB]$, s.t. $V(M(\gamma))=0$.
@@ -1049,7 +1063,7 @@ The latter shows that $1/\alpha_0$ is a positive eigenvalue of
 $A$ and $x_0$ is the corresponding non-negative left
 eigenvector.
 
-The classic result of **Perron and Frobenius** implies
+The classic result of *Perron and Frobenius* implies
 that a non-negative matrix  has a non-negative
 eigenvalue-eigenvector pair.
 

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -3,10 +3,12 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.17.2
 kernelspec:
-  display_name: Python 3
-  language: python
   name: python3
+  display_name: Python 3 (ipykernel)
+  language: python
 ---
 
 (von_neumann_model)=
@@ -16,6 +18,15 @@ kernelspec:
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">
         </a>
 </div>
+
+<style>
+/* Only expand code cells on this page */
+div.cell div.highlight,
+div.cell div.output_scroll {
+    max-height: none !important;
+    overflow-y: visible !important;
+}
+</style>
 ```
 
 ```{index} single: python
@@ -46,7 +57,7 @@ following important tools:
 
 We'll begin with some imports:
 
-```{code-cell} ipython
+```{code-cell} ipython3
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import fsolve, linprog
@@ -57,11 +68,10 @@ np.set_printoptions(precision=2)
 
 The code below provides the `Neumann` class
 
-```{code-cell} python3
----
-tags: [collapse-20]
----
-class Neumann(object):
+```{code-cell} ipython3
+:tags: [collapse-20]
+
+class Neumann:
 
     """
     This class describes the Generalized von Neumann growth model as it was
@@ -83,9 +93,9 @@ class Neumann(object):
         Ap - the cost of each activity
 
     Both A and B have non-negative entries. Moreover, we assume that
-    (1) Assumption I (every good which is consumed is also produced):
+    (1) Assumption 1 (every good which is consumed is also produced):
         for all j, b_{.,j} > 0, i.e. at least one entry is strictly positive
-    (2) Assumption II (no free lunch):
+    (2) Assumption 2 (no free lunch):
         for all i, a_{i,.} > 0, i.e. at least one entry is strictly positive
 
     Parameters
@@ -107,13 +117,13 @@ class Neumann(object):
         assert (self.A >= 0).all() and (self.B >= 0).all(), 'The input and \
               output matrices must have only non-negative entries!'
 
-        # (1) Check whether Assumption I is satisfied:
+        # (1) Check whether Assumption 1 is satisfied:
         if (np.sum(B, 0) <= 0).any():
             self.AI = False
         else:
             self.AI = True
 
-        # (2) Check whether Assumption II is satisfied:
+        # (2) Check whether Assumption 2 is satisfied:
         if (np.sum(A, 1) <= 0).any():
             self.AII = False
         else:
@@ -129,9 +139,9 @@ class Neumann(object):
           - number of goods          : {n}
           - number of activities     : {m}
 
-        Assumptions:
-          - AI:  every column of B has a positive entry    : {AI}
-          - AII: every row of A has a positive entry       : {AII}
+        Assumptions:// TODO:change {AI} variable into A1?
+          - A1:  every column of B has a positive entry    : {AI} 
+          - A2: every row of A has a positive entry       : {AII}
 
         """
         # Irreducible                                       : {irr}
@@ -372,18 +382,20 @@ an economy.
 
 Two key assumptions restrict economy $(A,B)$:
 
-- **Assumption I:** (every good that is consumed is also produced)
+````{prf:assumption} every good that is consumed is also produced)
+:label: assumption1
 
-  $$
+```{math}
   b_{.,j} > \mathbf{0}\hspace{5mm}\forall j=1,2,\dots,n
-  $$
+```
+````
 
-- **Assumption II:** (no free lunch)
-
-  $$
+````{prf:assumption} no free lunch
+:label: assumption2
+```{math}
   a_{i,.} > \mathbf{0}\hspace{5mm}\forall i=1,2,\dots,m
-  $$
-
+```
+````
 
 A semi-positive  *intensity* $m$-vector  $x$ denotes  levels at which
 activities are operated.
@@ -410,7 +422,8 @@ Satisfaction or a property of an input-output pair $(A,B)$ called *irreducibilit
 (or indecomposability) determines whether an economy can be decomposed
 into multiple     "sub-economies".
 
-**Definition:** For an economy $(A,B)$, the set of goods
+```{prf:definition}
+For an economy $(A,B)$, the set of goods
 $S\subset \{1,2,\dots,n\}$ is called an *independent subset* if
 it is possible to produce every good in $S$ without consuming
 goods from outside $S$. Formally, the set $S$ is independent if
@@ -419,10 +432,11 @@ that $a_{i,j}=0$ $\forall i\in T$ and $j\in S^c$ and
 for all $j\in S$, $\exists i\in T$ for which  $b_{i,j}>0$.
 The economy is **irreducible** if there are no proper independent
 subsets.
+```
 
 We study two examples, both in  Chapter 9.6 of Gale {cite}`gale1989theory`
 
-```{code-cell} python3
+```{code-cell} ipython3
 # (1) Irreducible (A, B) example: α_0 = β_0
 A1 = np.array([[0, 1, 0, 0],
                [1, 0, 0, 1],
@@ -449,14 +463,14 @@ B2 = np.array([[1, 0, 0, 1, 0, 0],
 The following code sets up our first Neumann economy or `Neumann`
 instance
 
-```{code-cell} python3
+```{code-cell} ipython3
 n1 = Neumann(A1, B1)
 n1
 ```
 
 Here is a second instance of a Neumann economy
 
-```{code-cell} python3
+```{code-cell} ipython3
 n2 = Neumann(A2, B2)
 n2
 ```
@@ -546,9 +560,11 @@ Two problems are connected by a remarkable dual
 relationship between  technological and valuation characteristics of
 the economy:
 
-**Definition:** The *technological expansion problem* (TEP) for the economy
+```{prf:definition}
+The *technological expansion problem* (TEP) for the economy
 $(A,B)$ is to find a semi-positive $m$-vector $x>0$
 and a number $\alpha\in\mathbb{R}$ that satisfy
+```
 
 $$
 \begin{aligned}
@@ -557,7 +573,7 @@ $$
     \end{aligned}
 $$
 
-Theorem 9.3 of David Gale’s book {cite}`gale1989theory` asserts that if Assumptions I and II are
+Theorem 9.3 of David Gale’s book {cite}`gale1989theory` asserts that if {prf:ref}`assumption1` and {prf:ref}`assumption2` are
 both satisfied, then a maximum value of $\alpha$ exists and that it is
 positive.
 
@@ -565,7 +581,8 @@ The maximal value is called the *technological expansion rate* and is denoted
 by $\alpha_0$. The associated intensity vector $x_0$ is the
 *optimal intensity vector*.
 
-**Definition:** The economic expansion problem (EEP) for
+```{prf:definition}
+The economic expansion problem (EEP) for
 $(A,B)$ is to find a semi-positive $n$-vector $p>0$
 and a number $\beta\in\mathbb{R}$ that satisfy
 
@@ -573,10 +590,11 @@ $$
 \begin{aligned}
     &\min_{\beta} \hspace{2mm} \beta\\
     &\text{s.t. }\hspace{2mm}Bp \leq \beta Ap
-    \end{aligned}
+\end{aligned}
 $$
+```
 
-Assumptions I and II imply existence of a minimum value
+{prf:ref}`assumption1` and {prf:ref}`assumption2` imply existence of a minimum value
 $\beta_0>0$ called the *economic expansion rate*.
 
 The corresponding price vector $p_0$ is the *optimal price vector*.
@@ -590,16 +608,19 @@ For convenience (and to emphasize a close connection to zero-sum games),  we nor
 $x_0$ and $p_0$ to have unit length.
 
 A standard duality argument (see Lemma 9.4. in (Gale, 1960) {cite}`gale1989theory`) implies
-that under Assumptions I and II, $\beta_0\leq \alpha_0$.
+that under {prf:ref}`assumption1` and {prf:ref}`assumption2`, $\beta_0\leq \alpha_0$.
 
 But to deduce that $\beta_0\geq \alpha_0$,
-Assumptions I and II are not sufficient.
+{prf:ref}`assumption1` and {prf:ref}`assumption2` are not sufficient.
 
 Therefore, von Neumann {cite}`von1937uber`  went on to prove the following remarkable
 “duality” result that connects TEP and EEP.
 
-**Theorem 1 (von Neumann):** If the economy $(A,B)$ satisfies
-Assumptions I and II, then there exist
+```{prf:theorem} von Neumann
+:label: theorem1
+
+If the economy $(A,B)$ satisfies
+{prf:ref}`assumption1` and {prf:ref}`assumption2`, then there exist
 $\left(\gamma^{*}, x_0, p_0\right)$, where
 $\gamma^{*}\in[\beta_0, \alpha_0]\subset\mathbb{R}$, $x_0>0$
 is an $m$-vector, $p_0>0$ is an $n$-vector, and the
@@ -612,9 +633,10 @@ Bp_0 &\leq \gamma^{* } Ap_0 \\
 x_0^T\left(B-\gamma^{* } A\right)p_0 &= 0
 \end{aligned}
 $$
+```
 
-```{note}
-*Proof (Sketch):* Assumption I and II imply that there exist $(\alpha_0,
+```{prf:proof} (Sketch)
+{prf:ref}`assumption1` and {prf:ref}`assumption2` imply that there exist $(\alpha_0,
 x_0)$ and $(\beta_0, p_0)$ that solve the TEP and EEP, respectively. If
 $\gamma^*>\alpha_0$, then by definition of $\alpha_0$, there cannot
 exist a semi-positive $x$ that satisfies $x^T B \geq \gamma^{* }
@@ -639,13 +661,13 @@ $\gamma^{*}$ (i.e., if it is *oversupplied*), then its price
 must be zero; and that if any activity provides negative profit, it must
 be unused.
 
-Therefore, the conditions stated in Theorem I ex encode all equilibrium conditions.
+Therefore, the conditions stated in {prf:ref}`theorem1` ex encode all equilibrium conditions.
 
-So  Theorem I essentially states that under Assumptions I and II there
+So  {prf:ref}`theorem1` essentially states that under {prf:ref}`assumption1` and {prf:ref}`assumption2` there
 always exists an equilibrium $\left(\gamma^{*}, x_0, p_0\right)$
 with balanced growth.
 
-Note that Theorem I is silent about uniqueness of the equilibrium. In
+Note that {prf:ref}`theorem1` is silent about uniqueness of the equilibrium. In
 fact, it does not rule out (trivial) cases with $x_0^TBp_0 = 0$ so
 that nothing of value is produced.
 
@@ -678,7 +700,8 @@ use mixed strategies. Thus,
 * the  row player chooses the $m$-vector $x > \mathbf{0}$ subject to $\iota_m^T x = 1$
 * the column player chooses the $n$-vector $p > \mathbf{0}$ subject to $\iota_n^T p = 1$.
 
-**Definition:** The $m\times n$ matrix game $C$ has the
+```{prf:definition}
+The $m\times n$ matrix game $C$ has the
 *solution* $(x^*, p^*, V(C))$ in mixed strategies if
 
 $$
@@ -689,6 +712,7 @@ $$
 $$
 
 The number $V(C)$ is called the *value* of the game.
+```
 
 From the above definition, it is clear that the value $V(C)$ has
 two alternative interpretations:
@@ -748,27 +772,26 @@ $$
 Hamburger, Thompson and Weil {cite}`hamburger1967computation` view the input-output pair of the
 economy as payoff matrices of two-player zero-sum games.
 
-Using this interpretation, they restate Assumption I and II as follows
+Using this interpretation, they restate {prf:ref}`assumption1` and {prf:ref}`assumption2` as follows
 
 $$
 V(-A) < 0\quad\quad \text{and}\quad\quad V(B)>0
 $$
 
-```{note}
-*Proof (Sketch)*:
+```{prf:proof} (Sketch)
 * $\Rightarrow$ $V(B)>0$ implies
 $x_0^T B \gg \mathbf{0}$, where $x_0$ is a maximizing
 vector. Since $B$ is non-negative, this requires that each
 column of $B$ has at least one positive entry, which is
-Assumption I.
-* $\Leftarrow$ From Assumption I and the fact
+{prf:ref}`assumption1`.
+* $\Leftarrow$ From {prf:ref}`assumption1` and the fact
 that $p>\mathbf{0}$, it follows that $Bp > \mathbf{0}$.
 This implies that the maximizing player can always choose $x$
 so that $x^TBp>0$ so that it must be the case
 that $V(B)>0$.
 ```
 
-In order to (re)state Theorem I in terms of a particular two-player
+In order to (re)state {prf:ref}`theorem1` in terms of a particular two-player
 zero-sum game, we define a matrix for $\gamma\in\mathbb{R}$
 
 $$
@@ -785,7 +808,7 @@ calculating the solution of the game implies
 - If $\gamma < \beta_0$, then for all $p>0$, there
   $\exists i\in\{1, \dots, m\}$, s.t.
   $[M(\gamma)p]_i > 0$ implying that $V(M(\gamma)) > 0$.
-- If $\gamma \in \{\beta_0, \alpha_0\}$, then (by Theorem I) the
+- If $\gamma \in \{\beta_0, \alpha_0\}$, then (by {prf:ref}`theorem1`) the
   optimal intensity and price vectors $x_0$ and $p_0$
   satisfy
 
@@ -808,8 +831,10 @@ $p''$ is optimal for the minimizing player in $M(\gamma'')$
 where $\gamma''\in(\beta_0, \gamma')$, then $(x', p'', 0)$
 is a solution for $M(\gamma)$ $\forall \gamma\in (\gamma'', \gamma')$.
 
-*Proof (Sketch):* If $x'$ is optimal for a maximizing player in
+```{prf:proof} (Sketch)
+If $x'$ is optimal for a maximizing player in
 game $M(\gamma')$, then $(x')^T M(\gamma')\geq \mathbf{0}^T$ and so for all $\gamma<\gamma'$.
+```
 
 $$
 (x')^T M(\gamma) = (x')^T M(\gamma') + (x')^T(\gamma' - \gamma)A \geq \mathbf{0}^T
@@ -864,7 +889,7 @@ solves $\min_j\{[\iota^T_m(B-\beta^{*} A)]_j\}=0$.
 
 The *bounds* method calculates these trivial bounds for us
 
-```{code-cell} python3
+```{code-cell} ipython3
 n1.bounds()
 ```
 
@@ -895,7 +920,7 @@ Compute $\alpha_0$ and $\beta_0$
 The *zerosum* method calculates the value and optimal strategies
 associated with a given $\gamma$.
 
-```{code-cell} python3
+```{code-cell} ipython3
 γ = 2
 
 print(f'Value of the game with γ = {γ}')
@@ -906,7 +931,7 @@ print('Price vector (from the dual)')
 print(n1.zerosum(γ=γ, dual=True)[1])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 numb_grid = 100
 γ_grid = np.linspace(0.4, 2.1, numb_grid)
 
@@ -932,7 +957,7 @@ plt.show()
 The *expansion* method implements the bisection algorithm for
 $\alpha_0$ (and uses the primal LP problem for $x_0$)
 
-```{code-cell} python3
+```{code-cell} ipython3
 α_0, x, p = n1.expansion()
 print(f'α_0 = {α_0}')
 print(f'x_0 = {x}')
@@ -942,7 +967,7 @@ print(f'The corresponding p from the dual = {p}')
 The *interest* method implements the bisection algorithm for
 $\beta_0$ (and uses the dual LP problem for $p_0$)
 
-```{code-cell} python3
+```{code-cell} ipython3
 β_0, x, p = n1.interest()
 print(f'β_0 = {β_0}')
 print(f'p_0 = {p}')
@@ -962,14 +987,14 @@ As an illustration, compute first the maximal and minimal roots of
 $V(M(\cdot))$ for our Example 2 that has a reducible
 input-output pair $(A, B)$
 
-```{code-cell} python3
+```{code-cell} ipython3
 α_0, x, p = n2.expansion()
 print(f'α_0 = {α_0}')
 print(f'x_0 = {x}')
 print(f'The corresponding p from the dual = {p}')
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 β_0, x, p = n2.interest()
 print(f'β_0 = {β_0}')
 print(f'p_0 = {p}')
@@ -982,7 +1007,7 @@ $\gamma^*$ that make the value of the game
 with $M(\gamma^*)$ zero. (see the figure above).
 
 Indeed, although the von Neumann theorem assures existence of the
-equilibrium, Assumptions I and II are not sufficient for uniqueness.
+equilibrium, {prf:ref}`assumption1` and {prf:ref}`assumption2` are not sufficient for uniqueness.
 Nonetheless, Kemeny et al. (1967) show that there are at most finitely
 many economic solutions, meaning that there are only finitely many
 $\gamma^*$ that satisfy $V(M(\gamma^*)) = 0$ and
@@ -995,8 +1020,12 @@ The following theorem (see Theorem 9.10. in Gale {cite}`gale1989theory`) asserts
 imposing irreducibility is sufficient for uniqueness of
 $(\gamma^*, x_0, p_0)$.
 
-**Theorem II:** Adopt the conditions of Theorem 1. If the economy
+```{prf:theorem}
+:label: theorem2
+
+Adopt the conditions of {prf:ref}`theorem1`. If the economy
 $(A,B)$ is irreducible, then $\gamma^*=\alpha_0=\beta_0$.
+```
 
 ### A Special Case
 
@@ -1004,11 +1033,13 @@ There is a special $(A,B)$ that allows us to simplify the solution
 method significantly by invoking the powerful Perron-Frobenius theorem
 for non-negative matrices.
 
-**Definition:** We call an economy *simple* if it satisfies
+```{prf:definition}
+We call an economy *simple* if it satisfies
 
 * $n=m$
 * Each activity produces exactly one good
 * Each good is produced by one and only one activity.
+```
 
 These assumptions imply that $B=I_n$, i.e., that $B$ can be
 written as an identity matrix (possibly after reshuffling its rows and

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -131,7 +131,7 @@ class Neumann:
           - number of goods          : {n}
           - number of activities     : {m}
 
-        Assumptions://
+        Assumptions:
           - AI:  every column of B has a positive entry    : {AI} 
           - AII: every row of A has a positive entry       : {AII}
 

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -334,19 +334,19 @@ $x\gg \mathbf{0}$ if $x_i>0$ for all $i=1,2,\dots,n$.
 We call a vector **non-negative** and write $x\geq \mathbf{0}$ if $x_i\geq 0$ for
 all $i=1,2,\dots,n$.
 
-We call a vector **semi-positive** and written $x > \mathbf{0}$ if
+We call a vector **semi-positive** written $x > \mathbf{0}$ if
 $x\geq \mathbf{0}$ and $x\neq \mathbf{0}$.
 
 For two conformable vectors $x$ and $y$, $x\gg y$,
 $x\geq y$ and $x> y$ mean $x-y\gg \mathbf{0}$,
 $x-y \geq \mathbf{0}$, and $x-y > \mathbf{0}$, respectively.
 
-We let all vectors in this lecture be column vectors; $x^{T}$ denotes the
+We let all vectors in this lecture be column vectors; $x^\top$ denotes the
 transpose of $x$ (i.e., a row vector).
 
 Let $\iota_n$ denote a
 column vector composed of $n$ ones, i.e.
-$\iota_n = (1,1,\dots,1)^T$.
+$\iota_n = (1,1,\dots,1)^\top$.
 
 Let $e^i$ denote a vector (of
 arbitrary size) containing zeros except for the $i$ th position
@@ -394,13 +394,13 @@ activities are operated.
 
 Therefore,
 
-- vector $x^T A$ gives the total amount of *goods used in
+- vector $x^\top A$ gives the total amount of *goods used in
   production*
-- vector $x^T B$ gives *total outputs*
+- vector $x^\top B$ gives *total outputs*
 
 An economy $(A,B)$ is said to be *productive*, if there exists a
 non-negative intensity vector $x \geq 0$ such
-that $x^T B > x^T A$.
+that $x^\top B > x^\top A$.
 
 The semi-positive $n$-vector $p$ contains prices assigned to
 the $n$ goods.
@@ -410,7 +410,7 @@ The $p$ vector implies *cost* and *revenue* vectors
 - the vector $Ap$ tells *costs* of the vector of activities
 - the vector $Bp$ tells *revenues* from the vector of activities
 
-Satisfaction or a property of an input-output pair $(A,B)$ called *irreducibility*
+Satisfaction of a property of an input-output pair $(A,B)$ called *irreducibility*
 (or indecomposability) determines whether an economy can be decomposed
 into multiple "sub-economies".
 
@@ -490,14 +490,14 @@ production.
 
 We assume that production (consumption of inputs) takes place in period
 $t$, while the consequent output materializes in period
-$t+1$, i.e., consumption of $x_{t}^TA$ in period $t$
-results in $x^T_{t}B$ amounts of output in period $t+1$.
+$t+1$, i.e., consumption of $x_{t}^\top A$ in period $t$
+results in $x^\top_{t}B$ amounts of output in period $t+1$.
 
 These timing conventions imply the following feasibility condition:
 
 $$
 \begin{aligned}
-x^T_{t}B \geq x^T_{t+1} A \hspace{1cm}\forall t\geq 1
+x^\top_{t}B \geq x^\top_{t+1} A \hspace{1cm}\forall t\geq 1
 \end{aligned}
 $$
 
@@ -524,7 +524,7 @@ With balanced growth, the law of motion of $x$ is evidently $x_{t+1}=\alpha x_t$
 and so we can rewrite the feasibility constraint as
 
 $$
-x^T_{t}B \geq \alpha x^T_t A \hspace{1cm}\forall t
+x^\top_{t}B \geq \alpha x^\top_t A \hspace{1cm}\forall t
 $$
 
 In the same spirit, define $\beta\in\mathbb{R}$ as the **interest
@@ -563,7 +563,7 @@ and a number $\alpha\in\mathbb{R}$ that satisfy
 $$
 \begin{aligned}
     &\max_{\alpha} \hspace{2mm} \alpha\\
-    &\text{s.t. }\hspace{2mm}x^T B \geq \alpha x^T A
+    &\text{s.t. }\hspace{2mm}x^\top B \geq \alpha x^\top A
     \end{aligned}
 $$
 ```
@@ -619,13 +619,13 @@ If the economy $(A,B)$ satisfies
 $\left(\gamma^{*}, x_0, p_0\right)$, where
 $\gamma^{*}\in[\beta_0, \alpha_0]\subset\mathbb{R}$, $x_0>0$
 is an $m$-vector, $p_0>0$ is an $n$-vector, and the
-following arbitrage true
+following arbitrage conditions hold
 
 $$
 \begin{aligned}
-x_0^T B &\geq \gamma^{* } x_0^T A \\
+x_0^\top B &\geq \gamma^{* } x_0^\top A \\
 Bp_0 &\leq \gamma^{* } Ap_0 \\
-x_0^T\left(B-\gamma^{* } A\right)p_0 &= 0
+x_0^\top \left(B-\gamma^{* } A\right)p_0 &= 0
 \end{aligned}
 $$
 ```
@@ -636,13 +636,13 @@ $$
 x_0)$ and $(\beta_0, p_0)$ that solve the TEP and EEP, respectively. 
 
 If $\gamma^*>\alpha_0$, then by definition of $\alpha_0$, there cannot
-exist a semi-positive $x$ that satisfies $x^T B \geq \gamma^{* }
-x^T A$.
+exist a semi-positive $x$ that satisfies $x^\top B \geq \gamma^{* }
+x^\top A$.
 
 Similarly, if $\gamma^*<\beta_0$, there is no semi-positive
 $p$ for which $Bp \leq \gamma^{* } Ap$. Let $\gamma^{*
-}\in[\beta_0, \alpha_0]$, then $x_0^T B \geq \alpha_0 x_0^T A \geq
-\gamma^{* } x_0^T A$.
+}\in[\beta_0, \alpha_0]$, then $x_0^\top B \geq \alpha_0 x_0^\top A \geq
+\gamma^{* } x_0^\top A$.
 
 Moreover, $Bp_0\leq \beta_0 A p_0\leq \gamma^* A
 p_0$. These two inequalities imply $x_0\left(B - \gamma^{* } A\right)p_0
@@ -656,27 +656,27 @@ We have already encountered and
 discussed the first two inequalities that represent feasibility and
 no-profit conditions.
 
-Moreover, the equality $x_0^T\left(B-\gamma^{* } A\right)p_0 = 0$ concisely expresses the
+Moreover, the equality $x_0^\top \left(B-\gamma^{* } A\right)p_0 = 0$ concisely expresses the
 requirements that if any good grows at a rate larger than
 $\gamma^{*}$ (i.e., if it is *oversupplied*), then its price
 must be zero; and that if any activity provides negative profit, it must
 be unused.
 
-Therefore, the conditions stated in {prf:ref}`theorem1` ex encode all equilibrium conditions.
+Therefore, the conditions stated in {prf:ref}`theorem1` encode all equilibrium conditions.
 
 So {prf:ref}`theorem1` essentially states that under {prf:ref}`assumption1` and {prf:ref}`assumption2` there 
 always exists an equilibrium $\left(\gamma^{*}, x_0, p_0\right)$
 with balanced growth.
 
 Note that {prf:ref}`theorem1` is silent about uniqueness of the equilibrium. In
-fact, it does not rule out (trivial) cases with $x_0^TBp_0 = 0$ so
+fact, it does not rule out (trivial) cases with $x_0^\top Bp_0 = 0$ so
 that nothing of value is produced.
 
 To exclude such uninteresting cases,
-Kemeny, Morgenstern and Thomspson {cite}`kemeny1956generalization` add an extra requirement
+Kemeny, Morgenstern and Thompson {cite}`kemeny1956generalization` add an extra requirement
 
 $$
-x^T_0 B p_0 > 0
+x^\top_0 B p_0 > 0
 $$
 
 and call the associated equilibria *economic solutions*.
@@ -690,7 +690,7 @@ significantly reduces the number of (relevant) solutions.
 To compute the equilibrium $(\gamma^{*}, x_0, p_0)$, we follow the
 algorithm proposed by Hamburger, Thompson and Weil (1967), building on
 the key insight that an equilibrium (with balanced growth) can be
-solves a particular two-player zero-sum game.
+solved as a particular two-player zero-sum game.
 
 First, we introduce some notation.
 
@@ -699,8 +699,8 @@ with the entries representing payoffs from the **minimizing** column
 player to the **maximizing** row player and assume that the players can
 use mixed strategies. Thus,
 
-* the row player chooses the $m$-vector $x > \mathbf{0}$ subject to $\iota_m^T x = 1$
-* the column player chooses the $n$-vector $p > \mathbf{0}$ subject to $\iota_n^T p = 1$.
+* the row player chooses the $m$-vector $x > \mathbf{0}$ subject to $\iota_m^\top x = 1$
+* the column player chooses the $n$-vector $p > \mathbf{0}$ subject to $\iota_n^\top p = 1$.
 
 ```{prf:definition}
 The $m\times n$ matrix game $C$ has the
@@ -708,8 +708,8 @@ The $m\times n$ matrix game $C$ has the
 
 $$
 \begin{aligned}
-(x^* )^T C e^j \geq V(C)\quad \forall j\in\{1, \dots, n\}\quad \quad
-\text{and}\quad\quad (e^i)^T C p^* \leq V(C)\quad \forall i\in\{1, \dots, m\}
+(x^* )^\top C e^j \geq V(C)\quad \forall j\in\{1, \dots, n\}\quad \quad
+\text{and}\quad\quad (e^i)^\top C p^* \leq V(C)\quad \forall i\in\{1, \dots, m\}
 \end{aligned}
 $$
 
@@ -720,10 +720,10 @@ From the above definition, it is clear that the value $V(C)$ has
 two alternative interpretations:
 
 * by playing the appropriate mixed
-  stategy, the maximizing player can assure himself at least $V(C)$
+  strategy, the maximizing player can assure himself at least $V(C)$
   (no matter what the column player chooses)
 * by playing the appropriate
-  mixed stategy, the minimizing player can make sure that the maximizing
+  mixed strategy, the minimizing player can make sure that the maximizing
   player will not get more than $V(C)$ (irrespective of what is the
   maximizing player’s choice)
 
@@ -734,7 +734,7 @@ zero-sum game.
 Moreover, von Neumann’s Minmax Theorem {cite}`neumann1928theorie` implies that
 
 $$
-V(C) = \max_x \min_p \hspace{2mm} x^T C p = \min_p \max_x \hspace{2mm} x^T C p = (x^*)^T C p^*
+V(C) = \max_x \min_p \hspace{2mm} x^\top C p = \min_p \max_x \hspace{2mm} x^\top C p = (x^*)^\top C p^*
 $$
 
 ### Connection with Linear Programming (LP)
@@ -743,8 +743,8 @@ Nash equilibria of a finite two-player zero-sum game solve a linear programming 
 
 To see this, we introduce the following notation
 
-* For a fixed $x$, let $v$ be the value of the minimization problem: $v \equiv \min_p x^T C p = \min_j x^T C e^j$
-* For a fixed $p$, let $u$ be the value of the maximization problem: $u \equiv \max_x x^T C p = \max_i (e^i)^T C p$
+* For a fixed $x$, let $v$ be the value of the minimization problem: $v \equiv \min_p x^\top C p = \min_j x^\top C e^j$
+* For a fixed $p$, let $u$ be the value of the maximization problem: $u \equiv \max_x x^\top C p = \max_i (e^i)^\top C p$
 
 Then the *max-min problem* (the game from the maximizing player’s point
 of view) can be written as the *primal* LP
@@ -752,9 +752,9 @@ of view) can be written as the *primal* LP
 $$
 \begin{aligned}
 V(C) = & \max \hspace{2mm} v \\
-\text{s.t. } \hspace{2mm} v \iota_n^T &\leq x^T C  \\
+\text{s.t. } \hspace{2mm} v \iota_n^\top &\leq x^\top C  \\
 x &\geq \mathbf{0} \\
-\iota_n^T x & = 1
+\iota_n^\top x & = 1
 \end{aligned}
 $$
 
@@ -766,7 +766,7 @@ $$
 V(C) = &\min \hspace{2mm} u \\
 \text{s.t. } \hspace{2mm}u \iota_m &\geq Cp  \\
 p &\geq \mathbf{0} \\
-\iota_m^T p & = 1
+\iota_m^\top p & = 1
 \end{aligned}
 $$
 
@@ -781,7 +781,7 @@ $$
 
 ```{prf:proof} (Sketch)
 * $\Rightarrow$ $V(B)>0$ implies
-$x_0^T B \gg \mathbf{0}$, where $x_0$ is a maximizing
+$x_0^\top B \gg \mathbf{0}$, where $x_0$ is a maximizing
 vector. Since $B$ is non-negative, this requires that each
 column of $B$ has at least one positive entry, which is
 {prf:ref}`assumption1`.
@@ -789,7 +789,7 @@ column of $B$ has at least one positive entry, which is
 * $\Leftarrow$ From {prf:ref}`assumption1` and the fact
 that $p>\mathbf{0}$, it follows that $Bp > \mathbf{0}$.
 This implies that the maximizing player can always choose $x$
-so that $x^TBp>0$ so that it must be the case
+so that $x^\top Bp>0$ so that it must be the case
 that $V(B)>0$.
 ```
 
@@ -805,7 +805,7 @@ calculating the solution of the game implies
 
 - If $\gamma > \alpha_0$, then for all $x>0$, there
   $\exists j\in\{1, \dots, n\}$, s.t.
-  $[x^T M(\gamma)]_j < 0$ implying
+  $[x^\top M(\gamma)]_j < 0$ implying
   that $V(M(\gamma)) < 0$.
 
 - If $\gamma < \beta_0$, then for all $p>0$, there
@@ -818,7 +818,7 @@ calculating the solution of the game implies
 
 $$
 \begin{aligned}
-x_0^T M(\gamma) \geq \mathbf{0}^T \quad \quad \text{and}\quad\quad M(\gamma) p_0 \leq \mathbf{0}
+x_0^\top M(\gamma) \geq \mathbf{0}^\top \quad \quad \text{and}\quad\quad M(\gamma) p_0 \leq \mathbf{0}
 \end{aligned}
 $$
 
@@ -837,15 +837,15 @@ is a solution for $M(\gamma)$ $\forall \gamma\in (\gamma'', \gamma')$.
 
 ```{prf:proof} (Sketch)
 If $x'$ is optimal for a maximizing player in
-game $M(\gamma')$, then $(x')^T M(\gamma')\geq \mathbf{0}^T$ and so for all $\gamma<\gamma'$.
+game $M(\gamma')$, then $(x')^\top M(\gamma')\geq \mathbf{0}^\top$ and so for all $\gamma<\gamma'$.
 ```
 
 $$
-(x')^T M(\gamma) = (x')^T M(\gamma') + (x')^T(\gamma' - \gamma)A \geq \mathbf{0}^T
+(x')^\top M(\gamma) = (x')^\top M(\gamma') + (x')^\top(\gamma' - \gamma)A \geq \mathbf{0}^\top
 $$
 
 hence $V(M(\gamma))\geq 0$. If $p''$ is optimal for a
-minimizing player in game $M(\gamma'')$, then $M(\gamma)p \leq \mathbf{0}$
+minimizing player in game $M(\gamma'')$, then $M(\gamma'')p'' \leq \mathbf{0}$
 and so for all $\gamma''<\gamma$
 
 $$
@@ -877,7 +877,7 @@ First, notice that we can easily find trivial upper and lower bounds for
 $\alpha_0$ and $\beta_0$.
 
 * TEP requires that
-$x^T(B-\alpha A)\geq \mathbf{0}^T$ and $x > \mathbf{0}$, so
+$x^\top (B-\alpha A)\geq \mathbf{0}^\top$ and $x > \mathbf{0}$, so
 if $\alpha$ is so large that
 $\max_i\{[(B-\alpha A)\iota_n]_i\} < 0$, then TEP ceases to have a
 solution.
@@ -887,9 +887,9 @@ solves $\max_i\{[(B-\alpha^{*} A)\iota_n]_i\} = 0$.
 
 * Similar to
 the upper bound, if $\beta$ is so low that
-$\min_j\{[\iota^T_m(B-\beta A)]_j\}>0$, then the EEP has no
+$\min_j\{[\iota^\top_m(B-\beta A)]_j\}>0$, then the EEP has no
 solution and so we can define **``LB``** as the $\beta^{*}$ that
-solves $\min_j\{[\iota^T_m(B-\beta^{*} A)]_j\}=0$.
+solves $\min_j\{[\iota^\top_m(B-\beta^{*} A)]_j\}=0$.
 
 The *bounds* method calculates these trivial bounds for us
 
@@ -912,7 +912,7 @@ Compute $\alpha_0$ and $\beta_0$
 
 - Finding $\beta_0$
     1. Fix $\gamma = \frac{UB + LB}{2}$ and compute the solution
-       of the two-player zero-sum game associated.
+       of the two-player zero-sum game associated
        with $M(\gamma)$. We can use either the primal or the dual
        LP problem.
     1. If $V(M(\gamma)) > 0$, then set $LB = \gamma$,
@@ -1017,7 +1017,7 @@ equilibrium, {prf:ref}`assumption1` and {prf:ref}`assumption2` are not sufficien
 Nonetheless, Kemeny et al. (1967) show that there are at most finitely
 many economic solutions, meaning that there are only finitely many
 $\gamma^*$ that satisfy $V(M(\gamma^*)) = 0$ and
-$x_0^TBp_0 > 0$ and that for each such $\gamma^*_i$, there
+$x_0^\top Bp_0 > 0$ and that for each such $\gamma^*_i$, there
 is a self-contained part of the economy (a sub-economy) that in
 equilibrium can expand independently with the expansion
 coefficient $\gamma^*_i$.
@@ -1055,8 +1055,8 @@ The simple model has the following special property (Theorem 9.11. in Gale {cite
 with $(A,I_n)$, then
 
 $$
-x_0^T = \alpha_0 x_0^T A\hspace{1cm}\Leftrightarrow\hspace{1cm}x_0^T
-A=\left(\frac{1}{\alpha_0}\right)x_0^T
+x_0^\top = \alpha_0 x_0^\top A\hspace{1cm}\Leftrightarrow\hspace{1cm}x_0^\top
+A=\left(\frac{1}{\alpha_0}\right)x_0^\top
 $$
 
 The latter shows that $1/\alpha_0$ is a positive eigenvalue of


### PR DESCRIPTION
Key changes
- Set the max-height of cells to none at the beginning
- Removed `object` after `class Nuemann`
- Adopted `sphinx-proof` environments

Question
- As I used the `sphinx-proof`, assumptions numbered as "I, II"  have been changed to "1, 2". But in the definition of `class Neumann`, some variables are named as `AI` and `AII`. Should I change the names of these variables to `A1` and `A2`? @mmcky

For example,
```
def __init__(self, A, B):

        self.A, self.B = list(map(self.convert, (A, B)))
        self.m, self.n = self.A.shape

        # Check if (A, B) satisfy the basic assumptions
        assert self.A.shape == self.B.shape, 'The input and output matrices \
              must have the same dimensions!'
        assert (self.A >= 0).all() and (self.B >= 0).all(), 'The input and \
              output matrices must have only non-negative entries!'

        # (1) Check whether Assumption 1 is satisfied:
        if (np.sum(B, 0) <= 0).any():
            self.AI = False
        else:
            self.AI = True

        # (2) Check whether Assumption 2 is satisfied:
        if (np.sum(A, 1) <= 0).any():
            self.AII = False
        else:
            self.AII = True
```

linked to #478 