### PR TITLE
[FIX] Fix jax and os.fork warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,8 @@ jobs:
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       - name: Upload Execution Reports (Download Notebooks)
         uses: actions/upload-artifact@v4
-        if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-notebooks
           path: _build/jupyter/reports
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
           pip install --upgrade "jax[cuda12-local]==0.6.2"
           pip install numpyro pyro-ppl
           python scripts/test-jax-install.py
+      - name: Install Chrome
+        shell: bash -l {0}
+        run: |
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     
+          sudo apt install -y ./google-chrome-stable_current_amd64.deb
+          google-chrome --version
       - name: Check nvidia Drivers
         shell: bash -l {0}
         run: nvidia-smi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
           pip install --upgrade "jax[cuda12-local]==0.6.2"
           pip install numpyro pyro-ppl
           python scripts/test-jax-install.py
-      - name: Install Chrome
-        shell: bash -l {0}
-        run: |
-          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     
-          sudo apt install -y ./google-chrome-stable_current_amd64.deb
-          google-chrome --version
+      # - name: Install Chrome
+      #   shell: bash -l {0}
+      #   run: |
+      #     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     
+      #     sudo apt install -y ./google-chrome-stable_current_amd64.deb
+      #     google-chrome --version
       - name: Check nvidia Drivers
         shell: bash -l {0}
         run: nvidia-smi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,6 @@ jobs:
           pip install --upgrade "jax[cuda12-local]==0.6.2"
           pip install numpyro pyro-ppl
           python scripts/test-jax-install.py
-      # - name: Install Chrome
-      #   shell: bash -l {0}
-      #   run: |
-      #     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     
-      #     sudo apt install -y ./google-chrome-stable_current_amd64.deb
-      #     google-chrome --version
       - name: Check nvidia Drivers
         shell: bash -l {0}
         run: nvidia-smi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       - name: Upload Execution Reports (Download Notebooks)
         uses: actions/upload-artifact@v4
+        if: failure()
         with:
           name: execution-reports-notebooks
           path: _build/jupyter/reports

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -37,11 +37,11 @@ sphinx:
     # false-positive links
     linkcheck_ignore: ['https://online.stat.psu.edu/stat415/book/export/html/834']
     bibtex_reference_style: author_year
+    suppress_warnings: ["mystnb.unknown_mime_type"]
     nb_mime_priority_overrides: [
        # HTML
        ['html', 'application/vnd.jupyter.widget-view+json', 10],
        ['html', 'application/javascript', 20],
-       ['html', 'application/vnd.colab-display-data+json', 25],
        ['html', 'text/html', 30],
        ['html', 'text/latex', 40],
        ['html', 'image/svg+xml', 50],

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -41,6 +41,7 @@ sphinx:
        # HTML
        ['html', 'application/vnd.jupyter.widget-view+json', 10],
        ['html', 'application/javascript', 20],
+       ['html', 'application/vnd.colab-display-data+json', 25],
        ['html', 'text/html', 30],
        ['html', 'text/latex', 40],
        ['html', 'image/svg+xml', 50],

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -21,8 +21,8 @@ In addition to what's included in base Anaconda, we need to install the followin
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install -U kaleido
-!conda install -y -c plotly plotly plotly-orca retrying
+!pip install -U kaleido plotly
+!conda install -y -c plotly plotly-orca
 ```
 
 We also need to install JAX to run this lecture

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -523,7 +523,7 @@ predictions = vmap(compute_xδw_seq, in_axes=(None, 0))(params_ex1, grid)[0][:, 
 
 ```{code-cell} ipython3
 fig = go.Figure()
-fig.add_trace(go.Scatter(x=grid, y=f_val, name=r'$-3x+2$'))
+fig.add_trace(go.Scatter(x=grid, y=f_val, name=r'-3x+2'))
 fig.add_trace(go.Scatter(x=grid, y=predictions, name='Approximation'))
 
 # Export to PNG file

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -23,6 +23,17 @@ In addition to what's included in base Anaconda, we need to install the followin
 
 !pip install -U kaleido plotly
 !conda install -y -c plotly plotly-orca
+
+# kaleido needs chrome to build images
+import kaleido
+kaleido.get_chrome_sync()
+```
+
+```{note}
+If you are running this on Google Colab the above cell will 
+present an error. This is because Google Colab doesn't use Anaconda to manage
+the Python packages. However this lecture will still execute as Google Colab
+has `plotly` installed.
 ```
 
 We also need to install JAX to run this lecture
@@ -35,15 +46,7 @@ We also need to install JAX to run this lecture
 
 ```{code-cell} ipython3
 import jax
-## to check that gpu is activated in environment
-print(f"JAX backend: {jax.devices()[0].platform}")
-```
-
-```{note}
-If you are running this on Google Colab the above cell will 
-present an error. This is because Google Colab doesn't use Anaconda to manage
-the Python packages. However this lecture will still execute as Google Colab
-has `plotly` installed.
+print(f"JAX backend: {jax.devices()[0].platform}") # to check that gpu is activated in environment
 ```
 
 ## Overview

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -23,7 +23,6 @@ In addition to what's included in base Anaconda, we need to install the followin
 
 !pip install -U kaleido plotly
 !conda install -y -c plotly plotly-orca
-!plotly_get_chrome
 ```
 
 We also need to install JAX to run this lecture

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -21,7 +21,7 @@ In addition to what's included in base Anaconda, we need to install the followin
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install kaleido
+!pip install -U kaleido
 !conda install -y -c plotly plotly plotly-orca retrying
 ```
 

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -23,6 +23,7 @@ In addition to what's included in base Anaconda, we need to install the followin
 
 !pip install -U kaleido plotly
 !conda install -y -c plotly plotly-orca
+!plotly_get_chrome
 ```
 
 We also need to install JAX to run this lecture

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -526,7 +526,7 @@ predictions = vmap(compute_xδw_seq, in_axes=(None, 0))(params_ex1, grid)[0][:, 
 
 ```{code-cell} ipython3
 fig = go.Figure()
-fig.add_trace(go.Scatter(x=grid, y=f_val, name=r'-3x+2'))
+fig.add_trace(go.Scatter(x=grid, y=f_val, name=r'$-3x+2$'))
 fig.add_trace(go.Scatter(x=grid, y=predictions, name='Approximation'))
 
 # Export to PNG file

--- a/lectures/back_prop.md
+++ b/lectures/back_prop.md
@@ -16,6 +16,17 @@ kernelspec:
 ```{include} _admonition/gpu.md
 ```
 
+In addition to what's included in base Anaconda, we need to install the following packages
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install kaleido
+!conda install -y -c plotly plotly plotly-orca retrying
+```
+
+We also need to install JAX to run this lecture
+
 ```{code-cell} ipython3
 :tags: [skip-execution]
 
@@ -26,15 +37,6 @@ kernelspec:
 import jax
 ## to check that gpu is activated in environment
 print(f"JAX backend: {jax.devices()[0].platform}")
-```
-
-In addition to what's included in base Anaconda, we need to install the following packages
-
-```{code-cell} ipython3
-:tags: [hide-output]
-
-!pip install kaleido
-!conda install -y -c plotly plotly plotly-orca retrying
 ```
 
 ```{note}

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -33,16 +33,16 @@ and the following package versions
 !conda list
 ```
 
+This lecture series has access to the following GPU
+
+```{code-cell} ipython
+!nvidia-smi
+```
+
 You can check the backend used by JAX using:
 
 ```{code-cell} ipython3
 import jax
 # Check if JAX is using GPU
 print(f"JAX backend: {jax.devices()[0].platform}")
-```
-
-and this lecture series also has access to the following GPU
-
-```{code-cell} ipython
-!nvidia-smi
 ```


### PR DESCRIPTION
This PR fixes the `os.fork` warning documented in #548.

This together with #556, fixes #548.