### PR TITLE
[harrison_kreps]: Fix axis

### DIFF
--- a/lectures/harrison_kreps.md
+++ b/lectures/harrison_kreps.md
@@ -414,7 +414,7 @@ def price_optimistic_beliefs(transitions, dividend_payoff, β=.75,
         p_old = p_new
         p_new = β * np.max([q @ p_old
                             + q @ dividend_payoff for q in transitions],
-                            1)
+                            axis=0)
 
         # If we succeed in converging, break out of for loop
         if np.max(np.sqrt((p_new - p_old)**2)) < tol:
@@ -422,7 +422,7 @@ def price_optimistic_beliefs(transitions, dividend_payoff, β=.75,
 
     ptwiddle = β * np.min([q @ p_old
                           + q @ dividend_payoff for q in transitions],
-                          1)
+                          axis=0)
 
     phat_a = np.array([p_new[0], ptwiddle[1]])
     phat_b = np.array([ptwiddle[0], p_new[1]])
@@ -482,7 +482,7 @@ def price_pessimistic_beliefs(transitions, dividend_payoff, β=.75,
         p_old = p_new
         p_new = β * np.min([q @ p_old
                             + q @ dividend_payoff for q in transitions],
-                           1)
+                           axis=0)
 
         # If we succeed in converging, break out of for loop
         if np.max(np.sqrt((p_new - p_old)**2)) < tol:


### PR DESCRIPTION
- Problem: np.max(..., axis=1) / np.min(..., axis=1) compares across states, not across investor types.
- Spec: Per equations (78.3) and (78.5), the max/min must be taken across types → axis=0.
- Fix: Replace axis=1 with axis=0 in the three lines below.