### PR TITLE
TST: setup action-translation-sync for testing

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -1,0 +1,26 @@
+name: Sync Translations
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+
+jobs:
+  sync-to-chinese:
+    # Only run when PR is merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Sync to Chinese Repository
+        uses: quantecon/action-translation-sync@v0.1
+        with:
+          target-repo: 'quantecon/lecture-python.zh-cn'
+          target-language: 'zh-cn'
+          docs-folder: 'lectures/'
+          source-language: 'en'
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}
+          pr-labels: 'translation-sync,automated,needs-review'
+          pr-reviewers: 'mmcky'  # Add your GitHub username


### PR DESCRIPTION
This PR sets up to enable testing of 

https://github.com/QuantEcon/action-translation-sync