### PR TITLE
[two_auctions] Fix conditional expectation simulation

### DIFF
--- a/lectures/two_auctions.md
+++ b/lectures/two_auctions.md
@@ -424,11 +424,11 @@ def evaluate_largest(v_hat, array, order=1):
 
 We can check the accuracy of our `evaluate_largest` method by comparing it with an analytical solution.
 
-We find that the evaluate_largest method functions well.
+We find that the `evaluate_largest` method functions well
 
 ```{code-cell} ipython3
-v_grid = np.linspace(0.3,1,8)
-bid_analytical = b_star(v_grid,N)
+v_grid = np.linspace(0.3, 1, 8)
+bid_analytical = b_star(v_grid, N)
 
 # Redraw valuations
 v = np.random.uniform(0, 1, (N, R))


### PR DESCRIPTION
## Before
<img width="541" height="402" alt="image" src="https://github.com/user-attachments/assets/9841c842-3804-48ed-830a-6580d173330b" />

Looking at such a figure which exhibits a systematic discrepancy, one should suspect that there should be a bug somewhere.

The values in the array `v` in this line https://github.com/QuantEcon/lecture-python.myst/blob/33416c7da68e67aa04213f6b218b953533c66db0/lectures/two_auctions.md?plain=1#L434 have already been sorted. One has to redraw random valuations to pass to `evaluate_largest`.

## After
<img width="541" height="402" alt="image" src="https://github.com/user-attachments/assets/beef25cb-0447-4150-a3a4-2c1e4c2ce186" />
