### PR TITLE
fix: Skip Netlify deployment for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   preview:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -168,6 +171,11 @@ jobs:
           fi
       - name: Preview Deploy to Netlify
         id: netlify-deploy
+        if: >
+          github.actor != 'dependabot[bot]' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          env.NETLIFY_AUTH_TOKEN != '' &&
+          env.NETLIFY_SITE_ID != ''
         shell: bash -l {0}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -238,11 +246,16 @@ jobs:
               echo "🎯 Preview page: ${deploy_url}/${{ github.event.inputs.preview_page }}"
             fi
           fi
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      - name: Skip Netlify Deploy (no secrets or untrusted actor)
+        if: >
+          !(github.actor != 'dependabot[bot]' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          env.NETLIFY_AUTH_TOKEN != '' &&
+          env.NETLIFY_SITE_ID != '')
+        run: |
+          echo "Skipping Netlify preview deploy: secrets unavailable or actor not trusted (actor=${{ github.actor }})"
       - name: Post PR Comment with Preview Links
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.netlify-deploy.outputs.deploy_url != ''
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem

PR #659 (and other Dependabot PRs) fail during the Netlify preview deployment step with:
```
Error: Unauthorized: could not retrieve project
```

**Root Cause:** GitHub's security model intentionally blocks repository secrets (`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`) from being accessible to Dependabot-triggered workflows. This prevents malicious dependency updates from exfiltrating secrets.

## Solution

This PR adds conditional logic to gracefully skip Netlify deployment when:
- Actor is `dependabot[bot]`
- PR is from a fork (security precaution)
- Required secrets are unavailable

## Changes

- ✅ Add `if` condition to Netlify deploy step checking for trusted actors and secret availability
- ✅ Move secrets to job-level `env` for proper conditional access
- ✅ Add informative skip message step for transparency in logs
- ✅ Update PR comment step to only run when deployment succeeds
- ✅ Maintain normal behavior for regular contributor PRs

## Outcome

After merging:
- Dependabot PRs will **pass CI** (skip Netlify gracefully with clear message)
- Regular contributor PRs will **continue to get Netlify previews**
- No security risks from exposing secrets to untrusted actors
- No workflow failures

## Testing

Once merged, re-run PR #659 or any other Dependabot PR to verify:
1. CI passes without errors
2. Logs show "Skipping Netlify preview deploy" message
3. Build continues normally (HTML, notebooks, PDF generation)

Fixes #659