### PR TITLE
[harrison_creps] Use linear solver instead of matrix inverse

### DIFF
--- a/lectures/harrison_kreps.md
+++ b/lectures/harrison_kreps.md
@@ -276,11 +276,14 @@ def price_single_beliefs(transition, dividend_payoff, β=.75):
     """
     Function to Solve Single Beliefs
     """
-    # First compute inverse piece
-    imbq_inv = la.inv(np.eye(transition.shape[0]) - β * transition)
+    # First compute (I - βQ)
+    A = np.eye(transition.shape[0]) - β * transition
 
-    # Next compute prices
-    prices = β * imbq_inv @ transition @ dividend_payoff
+    # Next compute βQd
+    b = β * (transition @ dividend_payoff)
+
+    # Solve linear system
+    prices = la.solve(A, b)
 
     return prices
 ```


### PR DESCRIPTION
This patch replaces the explicit inverse computation la.inv(I - βQ) with la.solve(I - βQ, βQd) in price_single_beliefs for better numerical stability and efficiency.

The output remains identical to the previous implementation.