### PR TITLE
Test sphinx-exercise PR #81: style_solution_after_exercise feature

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -122,8 +122,6 @@ sphinx:
       complex_and_trig: https://intro.quantecon.org/complex_and_trig.html
     # sphinx-proof
     proof_minimal_theme: true
-    # sphinx-exercise
-    exercise_style: "solution_follow_exercise"
     # sphinx-tojupyter
     tojupyter_static_file_path: ["source/_static", "_static"]
     tojupyter_target_html: true


### PR DESCRIPTION
## Purpose

This PR sets up a test environment to evaluate:
1. The new `exercise_style` feature from sphinx-exercise PR https://github.com/executablebooks/sphinx-exercise/pull/81
2. The latest quantecon-book-theme release (v0.10.1)

## Changes

1. **Updated `environment.yml`**: 
   - sphinx-exercise: Install from PR #81 branch
     - `sphinx-exercise @ git+https://github.com/executablebooks/sphinx-exercise.git@refs/pull/81/head`
   - quantecon-book-theme: Updated to release v0.10.1
     - `quantecon-book-theme==0.10.1`

2. **Updated `lectures/_config.yml`**: Enabled new configuration option
   - Added: `exercise_style: "solution_follow_exercise"`

## Testing Scope

This lecture series contains 20+ exercises across multiple files that will be affected by the new exercise styling:
- `wealth_dynamics.md`
- `odu.md`
- `mle.md`
- `ols.md`
- `likelihood_ratio_process_2.md`
- `finite_markov.md`
- `uncertainty_traps.md`
- `jv.md`
- `cass_fiscal.md`
- `likelihood_ratio_process.md`
- `prob_meaning.md`
- And more...

## Next Steps

1. Build the lectures to evaluate the new styling with the latest theme
2. Review HTML output to assess visual improvements
3. Provide feedback to sphinx-exercise maintainers

## Related

- sphinx-exercise PR: https://github.com/executablebooks/sphinx-exercise/pull/81
- quantecon-book-theme release: v0.10.1