### PR TITLE
FIX: duplicate equation label lake_lamda (latex)

### DIFF
--- a/lectures/endogenous_lake.md
+++ b/lectures/endogenous_lake.md
@@ -310,7 +310,7 @@ But their optimal decision rules determine the probability $\lambda$ of leaving 
 This is now
 
 ```{math}
-:label: lake_lamda
+:label: endogenous_lake_lambda
 
 \lambda
 = \gamma \mathbb P \{ w_t \geq \bar w\}
@@ -365,7 +365,7 @@ The lump-sum tax applies to everyone, including unemployed workers.
 For each specification $(c, \tau)$ of government policy, we can solve for the
 worker's optimal reservation wage.
 
-This determines $\lambda$ via {eq}`lake_lamda` evaluated at post tax wages,
+This determines $\lambda$ via {eq}`endogenous_lake_lambda` evaluated at post tax wages,
 which in turn determines a steady state unemployment rate $u(c, \tau)$.
 
 For a given level of unemployment benefit $c$, we can solve for a tax that balances the budget in the steady state


### PR DESCRIPTION
## Summary
This PR fixes a duplicate equation label warning that appears during builds.

## Changes
- Renamed equation label from `lake_lamda` to `endogenous_lake_lambda` in `lectures/endogenous_lake.md`
- Updated the corresponding equation reference to use the new label name

## Issue
Resolves the build warning:
```
/home/runner/_work/lecture-python.myst/lecture-python.myst/lectures/endogenous_lake.md:311: WARNING: duplicate label of equation lake_lamda, other instance in lake_model
```

## Testing
- The new label `endogenous_lake_lambda` is more specific and follows the naming convention already used in the file (e.g., `endogenous_lake_ex1`)
- All references have been updated accordingly