### PR TITLE
Rearrange savings lectures by splitting into two sections

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -72,14 +72,9 @@ parts:
   - file: jv
   - file: mccall_q
   - file: odu
-- caption: Consumption, Savings and Capital
+- caption: Household Problems
   numbered: true
   chapters:
-  - file: cass_koopmans_1
-  - file: cass_koopmans_2
-  - file: cass_fiscal
-  - file: cass_fiscal_2
-  - file: ak2
   - file: cake_eating_problem
   - file: cake_eating_numerical
   - file: optgrowth
@@ -97,6 +92,14 @@ parts:
   - file: perm_income
   - file: perm_income_cons
   - file: lq_inventories
+- caption: Optimal Growth
+  numbered: true
+  chapters:
+  - file: cass_koopmans_1
+  - file: cass_koopmans_2
+  - file: cass_fiscal
+  - file: cass_fiscal_2
+  - file: ak2
 - caption: Multiple Agent Models
   numbered: true
   chapters:


### PR DESCRIPTION
This commit reorganizes the table of contents to better structure the consumption and savings material:
- Renamed "Consumption, Savings and Capital" to "Household Problems"
- Moved optimal growth lectures (Cass-Koopmans, fiscal, AK models) to a new "Optimal Growth" section
- Kept household-focused lectures (cake eating, optimal growth, inventory, permanent income) in the Household Problems section

🤖 Generated with [Claude Code](https://claude.com/claude-code)