### PR TITLE
Standardize Job Search lecture titles to consistent I-IX numbering

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -70,8 +70,8 @@ parts:
   - file: mccall_correlated
   - file: career
   - file: jv
-  - file: mccall_q
   - file: odu
+  - file: mccall_q
 - caption: Household Problems
   numbered: true
   chapters:

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -18,7 +18,7 @@ kernelspec:
 </div>
 ```
 
-# Job Search V: Modeling Career Choice
+# Job Search VI: Modeling Career Choice
 
 ```{index} single: Modeling; Career Choice
 ```

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -18,7 +18,7 @@ kernelspec:
 </div>
 ```
 
-# {index}`Job Search VI: On-the-Job Search <single: Job Search VI: On-the-Job Search>`
+# {index}`Job Search VII: On-the-Job Search <single: Job Search VII: On-the-Job Search>`
 
 ```{index} single: Models; On-the-Job Search
 ```

--- a/lectures/mccall_correlated.md
+++ b/lectures/mccall_correlated.md
@@ -17,7 +17,7 @@ kernelspec:
 </div>
 ```
 
-# Job Search IV: Correlated Wage Offers
+# Job Search V: Correlated Wage Offers
 
 ```{contents} Contents
 :depth: 2

--- a/lectures/mccall_fitted_vfi.md
+++ b/lectures/mccall_fitted_vfi.md
@@ -17,7 +17,7 @@ kernelspec:
 </div>
 ```
 
-# Job Search III: Fitted Value Function Iteration
+# Job Search IV: Fitted Value Function Iteration
 
 ```{contents} Contents
 :depth: 2

--- a/lectures/mccall_model_with_sep_markov.md
+++ b/lectures/mccall_model_with_sep_markov.md
@@ -22,7 +22,7 @@ kernelspec:
 
 
 
-# Job Search with Separation and Markov Wages
+# Job Search III: Search with Separation and Markov Wages
 
 ```{index} single: An Introduction to Job Search
 ```

--- a/lectures/mccall_q.md
+++ b/lectures/mccall_q.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Job Search VII: A McCall Worker Q-Learns
+# Job Search IX: Search with Q-Learning
 
 ## Overview
 

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -18,7 +18,7 @@ kernelspec:
 </div>
 ```
 
-# Job Search VII: Search with Learning
+# Job Search VIII: Search with Learning
 
 ```{contents} Contents
 :depth: 2


### PR DESCRIPTION
## Summary

This PR standardizes all Job Search section lecture titles to follow a consistent "Job Search [Roman Numeral]: [Topic]" format (I through IX).

## Changes Made

### 1. Reordered Lectures in TOC
- Swapped the order of `odu` and `mccall_q` in `_toc.yml` to better reflect the progression from basic search with learning to advanced Q-learning techniques

### 2. Standardized All Titles (I-IX)

| Lecture | Old Title | New Title |
|---------|-----------|-----------|
| mccall_model.md | Job Search I: The McCall Search Model | ✓ (no change) |
| mccall_model_with_separation.md | Job Search II: Search and Separation | ✓ (no change) |
| mccall_model_with_sep_markov.md | ~~Job Search with Separation and Markov Wages~~ | **Job Search III: Search with Separation and Markov Wages** |
| mccall_fitted_vfi.md | ~~Job Search III~~ → | **Job Search IV: Fitted Value Function Iteration** |
| mccall_correlated.md | ~~Job Search IV~~ → | **Job Search V: Correlated Wage Offers** |
| career.md | ~~Job Search V~~ → | **Job Search VI: Modeling Career Choice** |
| jv.md | ~~Job Search VI~~ → | **Job Search VII: On-the-Job Search** |
| odu.md | ~~Job Search VII~~ → | **Job Search VIII: Search with Learning** |
| mccall_q.md | ~~Job Search VII: A McCall Worker Q-Learns~~ → | **Job Search IX: Search with Q-Learning** |

## Verification

✓ **Cross-references verified**: All internal references use file anchors (e.g., `{doc}mccall_model`) rather than title text, so no broken links were introduced  
✓ **Index entries updated**: The index directive in `jv.md` was also updated to reflect the new numbering

## Files Changed
- `_toc.yml` - Reordered lecture files
- `mccall_model_with_sep_markov.md` - Added consistent title prefix
- `mccall_fitted_vfi.md` - Renumbered III → IV
- `mccall_correlated.md` - Renumbered IV → V
- `career.md` - Renumbered V → VI
- `jv.md` - Renumbered VI → VII
- `odu.md` - Renumbered VII → VIII
- `mccall_q.md` - Renumbered VII → IX and simplified title

🤖 Generated with [Claude Code](https://claude.com/claude-code)