### PR TITLE
Update runs-on.yml with new AMI for CUDA 13.0 support

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -2,4 +2,5 @@ images:
   quantecon_ubuntu2404:
     platform: "linux"
     arch: "x64"
-    ami: "ami-09baf66e396fa7cfd"
+    ami: "ami-0edec81935264b6d3"
+    region: "us-west-2"


### PR DESCRIPTION
This PR updates the RunsOn configuration to use the new AMI with CUDA 13.0 and Driver 580.105.08.

## Changes:
- Updated AMI from `ami-09baf66e396fa7cfd` to `ami-0edec81935264b6d3`
- Added region specification: `us-west-2`
- Kept `quantecon_ubuntu2404` image name for compatibility

## Why this needs to be on main:
RunsOn reads the `.github/runs-on.yml` configuration from the main branch to map image names to AMI IDs. This must be merged to main before other branches can use the new AMI.