### PR TITLE
Simplify McCall model: Compute reservation wage directly from value function

### DIFF
--- a/lectures/mccall_model_with_sep_markov.md
+++ b/lectures/mccall_model_with_sep_markov.md
@@ -414,7 +414,6 @@ unemployed, 1 if employed) and $w_t$ is
 * their current wage, if employed. 
 
 ```{code-cell} ipython3
-@jax.jit
 def update_agent(key, status, wage_idx, model, w_star):
     """
     Updates an agent's employment status and current wage.


### PR DESCRIPTION
## Summary

This PR simplifies the job search model with separation and Markov wages by eliminating unnecessary intermediate computations and directly computing the reservation wage from the value function.

## Motivation

The original code computed an optimal policy array using `get_greedy`, then extracted the reservation wage from that policy. Since the optimal policy is a reservation wage strategy (accept all wages above a threshold), we can compute this threshold directly without the intermediate step.

## Key changes

### 1. Removed `get_greedy` function
- No longer needed since we don't compute a full policy array
- Simplifies the codebase

### 2. Modified `get_reservation_wage` function
- **Before**: Took a policy array `σ` and extracted the reservation wage
- **After**: Takes the value function `v_u` directly and computes the reservation wage by finding where acceptance becomes optimal
- Implementation: Finds lowest wage where `accept >= reject`

### 3. Updated `update_agent` function  
- **Before**: Took policy array `σ` and looked up `σ[wage_idx]` to make decisions
- **After**: Takes reservation wage `w_star` (scalar) and compares `w_vals[wage_idx] >= w_star`
- More efficient (no array indexing) and conceptually clearer

### 4. Updated all simulation functions
- `simulate_employment_path`: Now takes `w_star` instead of `σ`
- `_simulate_cross_section_compiled`: Now takes `w_star` instead of `σ`  
- `plot_cross_sectional_unemployment`: Computes `w_star` directly
- All code sections that solved the model simplified from:
  ```python
  v_star = vfi(model)
  σ_star = get_greedy(v_star, model)
  w_star = get_reservation_wage(σ_star, model)
  ```
  to:
  ```python
  v_star = vfi(model)
  w_star = get_reservation_wage(v_star, model)
  ```

## Benefits

1. **Simpler code**: Fewer functions, clearer logic flow
2. **More efficient**: 
   - No need to allocate/store full policy array
   - Direct scalar comparisons instead of array lookups in simulations
3. **Conceptually clearer**: Directly computes and uses the reservation wage threshold
4. **Easier to understand**: The reservation wage is the fundamental object of interest

## Testing

- Converted to Python script and verified all code runs successfully
- Output matches expected behavior (unemployment rates computed correctly)
- All plots and simulations work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)