### PR TITLE
TEST: Update sphinx-tojupyter to PR#56 (feature/myst-nb-glue-support)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.4post1
     - quantecon-book-theme==0.10.1
-    - sphinx-tojupyter==0.3.1
+    - git+https://github.com/QuantEcon/sphinx-tojupyter.git@feature/myst-nb-glue-support
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0
     - sphinx-proof==0.2.1


### PR DESCRIPTION
## Testing sphinx-tojupyter PR#56

This PR tests the new version of `sphinx-tojupyter` from PR https://github.com/QuantEcon/sphinx-tojupyter/pull/56

### Changes

- Updated `environment.yml` to install `sphinx-tojupyter` from the `feature/myst-nb-glue-support` branch instead of version `0.3.1`

### Purpose

Testing the `feature/myst-nb-glue-support` branch which adds support for myst-nb glue directives and ensures proper language metadata is set in generated Jupyter notebooks.

### Testing

- GitHub Actions CI will build HTML, PDF, and downloadable notebooks with the new version
- Local testing in `qetest` conda environment
- Verify generated notebooks in `_build/jupyter/` have correct language metadata

### Related

- Upstream PR: https://github.com/QuantEcon/sphinx-tojupyter/pull/56
- Testing branch: `feature/myst-nb-glue-support`