### PR TITLE
Upgrade sphinx-tojupyter to 0.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==1.0.4post1
     - quantecon-book-theme==0.10.1
-    - sphinx-tojupyter==0.3.1
+    - sphinx-tojupyter==0.4.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0
     - sphinx-proof==0.2.1


### PR DESCRIPTION
This PR upgrades sphinx-tojupyter from version 0.3.1 to 0.4.0 in the environment.yml file.

**Changes:**
- Updated `sphinx-tojupyter` dependency from 0.3.1 to 0.4.0

**Testing:**
The CI workflow will validate that the build completes successfully with the new version.