### PR TITLE
MAINT: upgrade quantecon-book-theme==v0.11.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.10.1
+    - quantecon-book-theme==0.11.0
     - sphinx-tojupyter==0.4.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0


### PR DESCRIPTION
This PR tests the latest version of quantecon-book-theme (v0.11.0).

Changes:
- Updated quantecon-book-theme from 0.10.1 to 0.11.0 in environment.yml

Release notes: https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.11.0

This will trigger CI builds to verify compatibility with the new theme version.