### PR TITLE
FIX: Enable nb_merge_streams in Sphinx config to fix code-cell streamed output formatting

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -38,6 +38,7 @@ sphinx:
     linkcheck_ignore: ['https://online.stat.psu.edu/stat415/book/export/html/834']
     bibtex_reference_style: author_year
     suppress_warnings: ["mystnb.unknown_mime_type"]
+    nb_merge_streams: true
     nb_mime_priority_overrides: [
        # HTML
        ['html', 'application/vnd.jupyter.widget-view+json', 10],


### PR DESCRIPTION
This PR enables `nb_merge_streams: true` in the Jupyter Book configuration to merge stdout and stderr streams in notebook outputs, displaying them in the order they were generated during execution.

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/325