### PR TITLE
FIX: Add fetch-depth: 0 to publish workflow for git metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
This PR fixes the publish workflow to properly support the git metadata features in quantecon-book-theme 0.12.0.

## Issue
The publish workflow was missing `fetch-depth: 0` in the checkout step, which means it only fetches a shallow clone without full git history. This prevents the theme from:
- Displaying the last modified timestamp
- Showing commit history in the changelog dropdown
- Linking to commit hashes and full history on GitHub

## Solution
Added `fetch-depth: 0` to the checkout action in the publish workflow, matching the configuration already present in the CI workflow.

## Context
The CI workflow already has this configuration (line 22), and the lecture-python-programming.myst repository also has it in both workflows. This brings consistency across all workflows.