### PR TITLE
Upgrade quantecon-book-theme to v0.13.0 - collapsible stderr warnings

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - git+https://github.com/QuantEcon/quantecon-book-theme.git@feature/collapsible-stderr-warnings
+    - quantecon-book-theme==0.13.0
     - sphinx-tojupyter==0.4.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0


### PR DESCRIPTION
## Overview
This PR upgrades quantecon-book-theme from v0.12.0 to v0.13.0, which includes the new collapsible stderr warnings feature.

## Changes
- Updated `environment.yml` to use `quantecon-book-theme==0.13.0` (released to PyPI)

## New Features in v0.13.0
✅ **Collapsible stderr warnings** - Automatic detection and collapsing of stderr output in notebook cells  
✅ Clean "⚠ Warnings" button UI with expand/collapse functionality  
✅ Improves readability by hiding verbose upstream warnings (JAX, CUDA, etc.)  
✅ Full dark mode support and accessibility features  
✅ Compatible with `merge_streams` option  
✅ No breaking changes - purely additive

## Problem Being Solved
When Jupyter notebooks execute code that produces warnings via stderr, these warnings can be verbose and visually distracting. Example warnings from QuantEcon lectures include:
- JAX CUDA initialization messages
- GPU interconnect warnings
- Other upstream package warnings

While useful for debugging, these warnings disrupt reading flow and take up significant visual space. The new feature automatically detects these warnings and provides a clean collapsible interface.

## Testing
Once merged, CI will build the lectures with the new theme version to validate:
- Stderr warnings are properly detected and collapsed
- Build process completes successfully  
- All existing functionality remains intact
- Dark mode styling works correctly

## Related
- QuantEcon/quantecon-book-theme#333 (feature PR)
- Released as v0.13.0 on PyPI