### PR TITLE
Add execution report uploads for all build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/upload-artifact@v5
         if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-latex
           path: _build/latex/reports
       # Final Build of HTML
       - name: Build HTML
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v5
         if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-html
           path: _build/html/reports
       - name: Install Node.js and Netlify CLI
         shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,12 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
+      - name: Upload Execution Reports (LaTeX)
+        uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: execution-reports-latex
+          path: _build/latex/reports
       - name: Copy LaTeX PDF for GH-PAGES
         shell: bash -l {0}
         run: |
@@ -60,6 +66,12 @@ jobs:
         run: |
           jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
           zip -r download-notebooks.zip _build/jupyter
+      - name: Upload Execution Reports (Download Notebooks)
+        uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: execution-reports-notebooks
+          path: _build/jupyter/reports
       - uses: actions/upload-artifact@v5
         with:
           name: download-notebooks
@@ -74,6 +86,12 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./ -n -W --keep-going
+      - name: Upload Execution Reports (HTML)
+        uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: execution-reports-html
+          path: _build/html/reports
       # Create HTML archive for release assets
       - name: Create HTML archive
         shell: bash -l {0}


### PR DESCRIPTION
## Summary

This PR adds comprehensive execution report uploads for all build steps in both the CI and publish workflows to help diagnose execution failures.

## Changes

### CI Workflow ()
- ✅ Updated LaTeX execution reports artifact name to `execution-reports-latex`
- ✅ Updated HTML execution reports artifact name to `execution-reports-html`
- ✅ Already had notebook execution reports as `execution-reports-notebooks`

### Publish Workflow (`publish.yml`)
- ✅ Added execution reports upload for LaTeX build step (`execution-reports-latex`)
- ✅ Added execution reports upload for Download Notebooks build (`execution-reports-notebooks`)
- ✅ Added execution reports upload for HTML build step (`execution-reports-html`)

## Benefits

- All three build steps (LaTeX PDF, Download Notebooks, HTML) now upload execution reports on failure
- Unique artifact names prevent conflicts when multiple steps fail
- Easier debugging of execution errors like the `lagrangian_lqdp.md` singular matrix error currently on main

## Testing

This PR will trigger the CI workflow which will test the updated artifact upload configuration. We can verify:
1. Execution reports are properly uploaded if any build step fails
2. Artifact names are unique and don't conflict
3. The existing execution error in `lagrangian_lqdp.md` is captured in reports