### PR TITLE
Update quantecon-book-theme to v0.13.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.13.0
+    - quantecon-book-theme==0.13.1
     - sphinx-tojupyter==0.4.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0


### PR DESCRIPTION
## Overview

Updates `quantecon-book-theme` from v0.13.0 to v0.13.1 to include an important bug fix.

## Changes

- Updates `environment.yml` to use `quantecon-book-theme==0.13.1`

## Bug Fix (v0.13.1)

### Fixed Colab Launch Button

- **Issue**: Colab launch button was generating incorrect URLs for flat notebook repositories
- **Solution**: Added `nb_path_to_notebooks` configuration option
- **Details**: The new option allows specifying notebook path independently from `path_to_docs`, defaulting to empty string for flat repositories

For flat notebook repositories (like ours), no additional configuration is needed - the fix works automatically.

See: https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.13.1