### PR TITLE
Update quantecon-book-theme to 0.15.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.14.0
+    - quantecon-book-theme==0.15.0
     - sphinx-tojupyter==0.4.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.0


### PR DESCRIPTION
This PR updates the quantecon-book-theme dependency from 0.14.0 to 0.15.0, the latest available version.