### PR TITLE
Pin quantecon-book-theme to 0.16.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
-    - quantecon-book-theme==0.17.1
+    - quantecon-book-theme==0.16.0
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -91,7 +91,6 @@ sphinx:
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
       analytics:
         google_analytics_id: G-J0SMYR4SG3
-      sticky_contents: true
       launch_buttons:
         colab_url                 : https://colab.research.google.com
     intersphinx_mapping: 


### PR DESCRIPTION
Pin quantecon-book-theme back to 0.16.0 due to dark code block background leakage in light mode.

The issue was introduced in v0.17.0 (color scheme system overhaul), not v0.18.0. v0.16.0 was the last published version without this problem. Also removes `sticky_contents: true` from `_config.yml` as it is a v0.17.0 feature.

See: https://github.com/QuantEcon/quantecon-book-theme/issues/372