### PR TITLE
PIN: myst-nb>=1.3.0,<1.4.0 to fix dark mode code cells

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
+    - myst-nb>=1.3.0,<1.4.0
     - quantecon-book-theme==0.18.0
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0


### PR DESCRIPTION
## Summary

Pin `myst-nb` to `>=1.3.0,<1.4.0` to fix dark code cell backgrounds appearing on the light-themed site for users with OS dark mode enabled.

## Root Cause

`myst-nb` 1.4.0 (released ~4 days ago) changed its CSS generation to use `@media (prefers-color-scheme: dark)` for system dark mode detection. Since this site does not explicitly set `data-theme` on the `<html>` element, the CSS falls back to the OS color scheme preference — causing dark code cell backgrounds on the light site for users with dark mode enabled.

The key PR in myst-nb that introduced this was [Improve theme integration #693](https://github.com/executablebooks/MyST-NB/pull/693).

### Evidence

Compared HTML release assets between `publish-2026feb26` (working) and `publish-2026mar07` (broken):
- All CSS, JS, and theme files in `_static/styles/` and `_static/scripts/` are **identical**
- The only difference is the **mystnb CSS file** generated by `myst-nb`, which changed from the old light-only variables with explicit `html[data-theme="dark"]` overrides to new `@media (prefers-color-scheme: dark/light)` rules with `--light`/`--dark` CSS custom properties

## Fix

Pin `myst-nb>=1.3.0,<1.4.0` in `environment.yml` to restore the previous CSS behavior.

Closes https://github.com/QuantEcon/quantecon-book-theme/issues/372
