### PR TITLE
Update quantecon-book-theme to 0.19.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
-    - myst-nb>=1.3.0,<1.4.0
-    - quantecon-book-theme==0.18.0
+    - quantecon-book-theme==0.19.0
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1


### PR DESCRIPTION
Updates `quantecon-book-theme` from 0.18.0 to [0.19.0](https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.19.0).

This also removes the explicit `myst-nb>=1.3.0,<1.4.0` pin from `environment.yml` as this dependency is now managed by the updated theme package.