### PR TITLE
Reduce bold font overuse in svd_intro lecture

### DIFF
--- a/lectures/svd_intro.md
+++ b/lectures/svd_intro.md
@@ -34,7 +34,7 @@ Let $X$ be an $m \times n$ matrix of rank $p$.
 
 Necessarily, $p \leq \min(m,n)$.
 
-In  much of this lecture, we'll think of $X$ as a matrix of **data** in which
+In  much of this lecture, we'll think of $X$ as a matrix of data in which
 
 * each column is an **individual** -- a time period or person, depending on the application
 
@@ -52,11 +52,11 @@ We'll apply a **singular value decomposition** of $X$ in both situations.
 
 In the $ m < < n$ case  in which there are many more individuals $n$ than attributes $m$, we can calculate sample moments of  a joint distribution  by taking averages  across observations of functions of the observations.
 
-In this $ m < < n$ case,  we'll look for **patterns** by using a **singular value decomposition** to do a **principal components analysis** (PCA).
+In this $ m < < n$ case,  we'll look for patterns by using a singular value decomposition to do a principal components analysis (PCA).
 
 In the $m > > n$  case in which there are many more attributes $m$ than individuals $n$ and when we are in a time-series setting in which $n$ equals the number of time periods covered in the data set $X$, we'll proceed in a different way.
 
-We'll again use a **singular value decomposition**,  but now to construct a **dynamic mode decomposition** (DMD)
+We'll again use a singular value decomposition,  but now to construct a **dynamic mode decomposition** (DMD)
 
 ## Singular Value Decomposition
 


### PR DESCRIPTION
## Summary

Closes #792 — the `svd_intro` lecture's "The Setting" section (section 5.2) overuses bold formatting, with 11 bold phrases across ~13 sentences and "singular value decomposition" bolded 3 times repeatedly.

This PR reduces the bold count in that section from 11 to 6 by:

- **Removing bold from "data"** (line 37): A common term that doesn't need typographic emphasis.
- **Removing bold from "patterns"** (line 55): A common term that doesn't need emphasis in context.
- **Removing bold from "singular value decomposition"** (lines 55, 59): Already bolded on first use in the section (line 51); repeating the bold on subsequent mentions adds visual noise without aiding comprehension.
- **Removing bold from "principal components analysis"** (line 55): Already introduced with bold in the Overview section (line 25).

Bold is preserved for:
- First-use introductions of key terms: **individual**, **random variable**, **short and fat**, **tall and skinny**, **singular value decomposition** (first occurrence)
- **dynamic mode decomposition** — its first appearance in the body text

## Principle applied

Bold only on first introduction of a term; avoid re-bolding terms the reader has already encountered.

## Test plan

- [ ] Verify the rendered lecture reads naturally without excessive emphasis
- [ ] Confirm key terms are still bolded on first use for discoverability

🤖 Generated with [Claude Code](https://claude.com/claude-code)