### PR TITLE
update quantecon-book-theme to 0.20.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
-    - quantecon-book-theme==0.20.1
+    - quantecon-book-theme @ git+https://github.com/QuantEcon/quantecon-book-theme.git@fix/citation-em-sibling-selector
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1


### PR DESCRIPTION
## Update `quantecon-book-theme`

This PR updates the theme to test the citation emphasis fix from [QuantEcon/quantecon-book-theme#378](https://github.com/QuantEcon/quantecon-book-theme/pull/378).

### What's being tested

The theme's emphasis styling (`em` elements display in teal color instead of italics) was incorrectly applied to "et al." text in `sphinxcontrib-bibtex` textual citations (`:cite:t:` with `author_year` style).

The fix adds a CSS `:has()` selector to match the HTML structure where `<em>et al.</em>` is a sibling of the `<a class="reference">` link, not a child.

### Preview pages to check

- [doubts_or_variability](../doubts_or_variability) — has multiple `Barillas et al. [2009]` citations

### Next steps

Once the preview build confirms the fix works:
1. Merge [quantecon-book-theme#378](https://github.com/QuantEcon/quantecon-book-theme/pull/378)
2. Release `quantecon-book-theme` v0.20.2
3. Update this PR to pin `quantecon-book-theme==0.20.2`
4. Merge this PR
