### PR TITLE
update quantecon-book-theme to 0.20.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
-    - quantecon-book-theme==0.19.0
+    - quantecon-book-theme==0.20.2
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1


### PR DESCRIPTION
## Update `quantecon-book-theme` to 0.20.2

Bumps `quantecon-book-theme` from `0.19.0` to `0.20.2`.

### Changes included

**v0.20.2** ([release notes](https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.20.2))
- Fixed emphasis color on "et al." in textual citations — added `span:has(> a.reference) > em` CSS selector to handle the HTML structure from sphinxcontrib-bibtex `author_year` style

**v0.20.1** ([release notes](https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.20.1))
- Initial fix for emphasis color on citation reference links (`a.reference em`)
- Relaxed `sphinxcontrib-bibtex` upper bound from `<=2.5.0` to `<3`

**v0.20.0** ([release notes](https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.20.0))
- Language switcher for multilingual site support
- SEO hreflang tags

### Preview pages to check
- [doubts_or_variability](../doubts_or_variability) — verify "Barillas et al. [2009]" renders without teal emphasis color
