### PR TITLE
FIX: Define missing discount factor to resolve NameError in MPE notebook

### DIFF
--- a/lectures/markov_perf.md
+++ b/lectures/markov_perf.md
@@ -446,8 +446,9 @@ In particular, let's take F2 as computed above, plug it into {eq}`eq_mpe_p1p` an
 We hope that the resulting policy will agree with F1 as computed above
 
 ```{code-cell} ipython3
+beta = 0.96
 Λ1 = A - B2 @ F2
-lq1 = qe.LQ(Q1, R1, Λ1, B1, beta=β)
+lq1 = qe.LQ(Q1, R1, Λ1, B1, beta=beta)
 P1_ih, F1_ih, d = lq1.stationary_values()
 F1_ih
 ```


### PR DESCRIPTION
Description:
In the Markov Perfect Equilibrium lecture, the cell calculating the LQ stationary values throws a NameError during notebook execution. This occurs because the discount factor (beta = 0.96) is defined inside the external script duopoly_mpe.py. Since the :load: directive only renders the script statically without executing it in the active Jupyter kernel, beta remains undefined in the notebook namespace.

This PR explicitly defines beta = 0.96 in the execution cell to ensure the qe.LQ model initializes correctly and the notebook builds successfully.