### PR TITLE
Sync Colab workflow deps with environment.yml

### DIFF
--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Build Software & LaTeX
         shell: bash -l {0}
         run: |
-          pip install jupyter-book==1.0.3 quantecon-book-theme==0.8.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinxcontrib-youtube==1.3.0 sphinx-togglebutton==0.3.2 arviz sphinx-proof sphinx-exercise sphinx-reredirects
+          pip install "jupyter-book>=1.0.4post1,<2.0" quantecon-book-theme==0.20.2 sphinx-tojupyter==0.6.0 sphinxext-rediraffe==0.3.0 sphinx-exercise==1.2.1 sphinx-proof==0.4.0 sphinxcontrib-youtube==1.5.0 sphinx-togglebutton==0.4.5 sphinx-reredirects==1.1.0 arviz
           apt-get update
           apt-get install dvipng texlive texlive-latex-extra texlive-fonts-recommended cm-super    
       - name: Check nvidia drivers


### PR DESCRIPTION
## Summary

- The Colab execution-check workflow installed stale pins (`quantecon-book-theme==0.8.2`, unpinned `sphinx-exercise` resolving to `1.0.1`, plus older `jupyter-book`, `sphinx-tojupyter`, etc.) that no longer recognise the `sticky_contents` and `exercise_style` options set in `lectures/_config.yml`.
- The two resulting Sphinx warnings tripped `-W` in [.github/workflows/collab.yml:46](.github/workflows/collab.yml#L46), producing a misleading "Colab Execution Check Failed" issue (#868) even though all 110 notebooks executed successfully (the upload step reported `No files were found with the provided path: _build/html/reports`).
- Align the install line with `environment.yml` so the workflow validates the same stack the book is published with.

Closes #868.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm `Build HTML` succeeds (no `unknown config value 'exercise_style'` / `unsupported theme option 'sticky_contents'` warnings).
- [ ] Confirm no new `Weekly Colab Execution Check Failed` issue is filed on the next Monday 04:00 UTC run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)