### PR TITLE
[lln_clt.md] Update np.random → Generator API

### DIFF
--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -444,7 +444,7 @@ $Y_5$
 ```{code-cell} python3
 beta_dist = beta(2, 2)
 
-def gen_x_draws(k):
+def gen_x_draws(k, rng):
     """
     Returns a flat array containing k independent draws from the
     distribution of X, the underlying random variable.  This distribution
@@ -456,7 +456,7 @@ def gen_x_draws(k):
     bdraws[1, :] += 0.6
     bdraws[2, :] -= 1.1
     # Set X[i] = bdraws[j, i], where j is a random draw from {0, 1, 2}
-    js = np.random.randint(0, 2, size=k)
+    js = rng.integers(0, 2, size=k)
     X = bdraws[js, np.arange(k)]
     # Rescale, so that the random variable is zero mean
     m, sigma = X.mean(), X.std()
@@ -465,11 +465,12 @@ def gen_x_draws(k):
 nmax = 5
 reps = 100000
 ns = list(range(1, nmax + 1))
+rng = np.random.default_rng()
 
 # Form a matrix Z such that each column is reps independent draws of X
 Z = np.empty((reps, nmax))
 for i in range(nmax):
-    Z[:, i] = gen_x_draws(reps)
+    Z[:, i] = gen_x_draws(reps, rng)
 # Take cumulative sum across columns
 S = Z.cumsum(axis=1)
 # Multiply j-th column by sqrt j


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `lln_clt.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The single legacy call `np.random.randint` inside `gen_x_draws` has been replaced with `rng.integers` from a `np.random.default_rng()` generator.

## Details

`rng` is introduced as an explicit required argument to `gen_x_draws(k, rng)`, and `rng = np.random.default_rng()` is defined in the same cell just before the call site. Since `rng` is always available at the point of use, no `rng=None` fallback was added.

This differs from the approach taken in a related PR ([lecture-python-intro#741](https://github.com/QuantEcon/lecture-python-intro/pull/741/changes)), where `rng` was created once at the top of the lecture and reused across multiple cells — so functions there could be called from contexts where `rng` was not always explicitly passed, making the `if rng is None` fallback reasonable. In this lecture, `rng` is created in the same cell as the function definition and its call site, so the fallback seemed unnecessary.

I'd welcome your thoughts on whether this difference in approach is appropriate, or whether a consistent `rng=None` pattern should be preferred across lectures.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
