### PR TITLE
Reduce link checker noise and fix broken DOI (#906)

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -21,7 +21,10 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --accept 200,403,503 *.html
+          # --root-dir resolves root-relative links (e.g. /_notebooks/*.ipynb,
+          # /_pdf/quantecon-python.pdf) against the gh-pages checkout so they are
+          # not reported as errors. See QuantEcon/lecture-python.myst#906.
+          args: --root-dir ${{ github.workspace }} --accept 200,403,503 *.html
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v6

--- a/lectures/_static/quant-econ.bib
+++ b/lectures/_static/quant-econ.bib
@@ -3984,8 +3984,7 @@
   year    = {1980},
   volume  = {70},
   number  = {3},
-  pages   = {393--408},
-  doi     = {10.2307/1805228}
+  pages   = {393--408}
 }
 
 @article{AndersonSonnenschein1982,


### PR DESCRIPTION
## Summary

Triage of the weekly link checker report (#906). It reported **241 errors**, but ~237 were noise from how lychee is invoked. This PR removes that noise and fixes the one genuine issue.

### Breakdown of #906

| Bucket | Count | Real? |
|---|---|---|
| Root-relative links `/_notebooks/*.ipynb` + `/_pdf/quantecon-python.pdf` (2 per lecture page) | ~234 | ❌ config |
| `file://…/None` artifacts on generated pages (`genindex`, `prf-prf`, `search`) | 3 | ❌ generated |
| External links in `two_auctions` / `zreferences` | 4 | ⚠️ mostly false positives |

I verified the four external links with live requests:

- `chekuri.cs.illinois.edu/.../Notes20.pdf` → **200** (the `415` was HEAD/accept-header handling)
- `s2.smu.edu/tsalmon/auctions.pdf` → **200** (the network error was transient in CI)
- `doi.org/10.3905/jod.2012.20.1.038` → valid DOI, just 302s into a paywalled login
- `doi.org/10.2307/1805228` → **genuine 404** — unregistered at doi.org

## Changes

**1. `linkcheck.yml` — pass `--root-dir`.** Lychee runs against the `gh-pages` checkout with no root directory, so every root-relative link (`/_notebooks/…`, `/_pdf/…`) errors with *"To resolve root-relative links in local files, provide a root dir"*. Those files exist in the build; `--root-dir ${{ github.workspace }}` resolves them locally, eliminating ~234 of the 241 errors and leaving future reports as signal.

**2. `quant-econ.bib` — drop the broken DOI.** The `GrossmanStiglitz1980` entry's DOI `10.2307/1805228` is unregistered (real 404). Crossref has no registered DOI for the original 1980 AER article, so the `doi` field is removed; the citation (author/title/journal/year/vol/pages) remains complete.

## Note on `QuantEcon/actions`

I also checked whether the shared linkchecker in `QuantEcon/actions` is ready to migrate to — it is **not built yet**. It exists only as a proposal in `docs/FUTURE-DEVELOPMENT.md` and is marked "out of scope (standalone)" in `PLAN.md`. When that wrapper is built, it should bake in `--root-dir`/base-URL handling and exclusion patterns so this noise does not recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)