### PR TITLE
[collab] Sync build-tool pins with environment.yml to fix weekly execution check

### DIFF
--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -18,7 +18,17 @@ jobs:
       - name: Install Build Software & LaTeX
         shell: bash -l {0}
         run: |
-          pip install "jupyter-book>=1.0.4post1,<2.0" quantecon-book-theme==0.21.0 sphinx-tojupyter==0.6.0 sphinxext-rediraffe==0.3.0 sphinxcontrib-youtube==1.5.0 sphinx-togglebutton==0.4.5 arviz sphinx-proof==0.4.0 sphinx-exercise==1.2.1 sphinx-reredirects==1.1.0
+          pip install \
+            "jupyter-book>=1.0.4post1,<2.0" \
+            quantecon-book-theme==0.21.0 \
+            sphinx-tojupyter==0.6.0 \
+            sphinxext-rediraffe==0.3.0 \
+            sphinxcontrib-youtube==1.5.0 \
+            sphinx-togglebutton==0.4.5 \
+            arviz \
+            sphinx-proof==0.4.0 \
+            sphinx-exercise==1.2.1 \
+            sphinx-reredirects==1.1.0
           apt-get update
           apt-get install dvipng texlive texlive-latex-extra texlive-fonts-recommended cm-super    
       - name: Check nvidia drivers

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Build Software & LaTeX
         shell: bash -l {0}
         run: |
-          pip install jupyter-book==1.0.3 quantecon-book-theme==0.8.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinxcontrib-youtube==1.3.0 sphinx-togglebutton==0.3.2 arviz sphinx-proof sphinx-exercise sphinx-reredirects
+          pip install "jupyter-book>=1.0.4post1,<2.0" quantecon-book-theme==0.21.0 sphinx-tojupyter==0.6.0 sphinxext-rediraffe==0.3.0 sphinxcontrib-youtube==1.5.0 sphinx-togglebutton==0.4.5 arviz sphinx-proof==0.4.0 sphinx-exercise==1.2.1 sphinx-reredirects==1.1.0
           apt-get update
           apt-get install dvipng texlive texlive-latex-extra texlive-fonts-recommended cm-super    
       - name: Check nvidia drivers


### PR DESCRIPTION
## What this fixes

The weekly Google Colab execution check ([collab.yml](.github/workflows/collab.yml)) has been failing every week (issue #905, and identically for the prior ~6 weeks). Despite the auto-generated "execution failure" title, **no notebook actually fails to execute** — every executed notebook succeeds and the `_build/html/reports` artifact is empty.

The build runs with `-W --keep-going`, so any warning is fatal. The hand-maintained pip install in `collab.yml` had drifted far behind [environment.yml](environment.yml), producing two config-compat warnings that failed the build:

| Warning | Cause |
| --- | --- |
| `unsupported theme option 'sticky_contents' given` | `quantecon-book-theme==0.8.2` predates the `sticky_contents` option (added in theme 0.17.1) |
| `unknown config value 'exercise_style' in override, ignoring` | unpinned `sphinx-exercise` resolved to a version that no longer registers `exercise_style` |

The regular `ci.yml` build — which uses the correct `environment.yml` versions — passes on main, confirming the book is healthy and the problem is isolated to this workflow's dependency install.

## The change

Pin the build tools in `collab.yml` to the same versions `environment.yml` uses (and that `ci.yml` builds against cleanly). The list is kept explicit rather than switching to `pip install -r requirements.txt`, since the whole point of this job is to layer the build tools on top of the Colab `runtime:latest` scientific stack without clobbering its pinned numpy/scipy/jax/etc.

| Package | Before | After |
| --- | --- | --- |
| jupyter-book | `==1.0.3` | `>=1.0.4post1,<2.0` |
| quantecon-book-theme | `==0.8.2` | `==0.21.0` |
| sphinx-tojupyter | `==0.3.0` | `==0.6.0` |
| sphinxext-rediraffe | `==0.2.7` | `==0.3.0` |
| sphinxcontrib-youtube | `==1.3.0` | `==1.5.0` |
| sphinx-togglebutton | `==0.3.2` | `==0.4.5` |
| sphinx-proof | unpinned | `==0.4.0` |
| sphinx-exercise | unpinned | `==1.2.1` |
| sphinx-reredirects | unpinned | `==1.1.0` |

Pinning `quantecon-book-theme==0.21.0` clears the `sticky_contents` warning and `sphinx-exercise==1.2.1` clears the `exercise_style` warning.

## Follow-up

This drift will recur unless build-tool versions are kept in sync. Worth having dependency bumps (e.g. the recent #896) also touch `collab.yml`, or centralizing these versions.

Fixes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)