### PR TITLE
Add explanatory notes to bayes_nonconj: NUTS and variational inference

### DIFF
--- a/lectures/bayes_nonconj.md
+++ b/lectures/bayes_nonconj.md
@@ -356,6 +356,24 @@ MCMC approximates the posterior by *sampling* from it.
 
 We restrict attention to a tractable family of densities $q_\phi(\theta)$ — the **guide** — indexed by parameters $\phi$, and we search for the member of that family closest to the posterior.
 
+### Why variational inference?
+
+If NUTS already returns accurate posteriors, why introduce another method?
+
+The answer is **scale**.
+
+MCMC evaluates the likelihood over the entire dataset at every step, and the number of steps it needs tends to grow with the dimension of the parameter.
+
+For large datasets or high-dimensional models — for instance the hierarchical models and neural networks common in machine learning — this can become too slow to be practical.
+
+Variational inference scales much better, because the objective (the ELBO, introduced below) can be maximized with *stochastic* gradients computed on small random subsets of the data — the same machinery that trains deep learning models.
+
+It also yields a compact parametric approximation that is cheap to store and to draw from afterwards.
+
+The price is accuracy: VI returns only the best fit *within the guide family*, and it can understate uncertainty.
+
+As a rule of thumb, prefer MCMC when you need an accurate posterior and the problem is small enough to afford it, and VI when the model is too large for MCMC or a fast, approximate answer is good enough.
+
 ### The evidence lower bound
 
 Let the prior be $p(\theta)$ and the likelihood be $p(Y \mid \theta)$, where $Y$ denotes the observed data (here the head count $k$).

--- a/lectures/bayes_nonconj.md
+++ b/lectures/bayes_nonconj.md
@@ -44,6 +44,16 @@ This lecture introduces two widely used ways to do that, both implemented in the
 
 * **Variational inference (VI)** — replace sampling with optimization: search within a tractable family of distributions for the member closest to the posterior.
 
+```{note}
+We treat NUTS as a black box in this lecture.
+
+In brief, it is a form of **Hamiltonian Monte Carlo**, which is itself a version of the **Metropolis–Hastings** algorithm: it proposes candidate draws and accepts or rejects them so that the resulting Markov chain has the posterior as its stationary distribution.
+
+What distinguishes it from a basic Metropolis–Hastings sampler is that its proposals are built from *gradient* (derivative) information about the log-posterior, which lets the chain move efficiently through the parameter space; NUTS additionally tunes the length of each proposed move automatically.
+
+For a more advanced introduction to MCMC and the Metropolis–Hastings algorithm, see [this lecture](https://python-advanced.quantecon.org/mcmc.html).
+```
+
 Our plan is:
 
 1. Confirm that MCMC reproduces the *conjugate* beta posterior that we can compute analytically — this validates the machinery on a problem whose answer we already know.

--- a/lectures/bayes_nonconj.md
+++ b/lectures/bayes_nonconj.md
@@ -193,24 +193,44 @@ We take $\alpha_0 = \beta_0 = 2$ and sample the posterior with NUTS.
 mcmc = run_nuts(binomial_model, dist.Beta(α0, β0), k, n)
 ```
 
-Before looking at the posterior we check that the sampler converged.
+Before looking at the posterior we should check that the sampler has done its job.
 
-ArviZ reads NumPyro's output directly and reports standard diagnostics.
+Unlike the independent draws we are used to, MCMC returns a *dependent* sequence — a Markov chain — whose early draws still remember where the chain started.
+
+We can trust the output only once the chain has "forgotten" its starting point and settled into its stationary distribution, which by construction is the posterior we want.
+
+As a safeguard we ran **four** chains from different random starting points (`num_chains=4` in `run_nuts`) and now check that they agree with one another.
+
+[ArviZ](https://www.arviz.org/) is a companion library for examining the output of Bayesian samplers.
+
+The function `az.from_numpyro` repackages our NumPyro results into ArviZ's standard data structure, and `az.summary` prints a table of per-parameter summaries and convergence diagnostics.
 
 ```{code-cell} ipython3
 idata = az.from_numpyro(mcmc)
 az.summary(idata, var_names=["θ"])
 ```
 
-The potential scale reduction factor `r_hat` is essentially $1.0$ and the effective sample sizes are large, both signs that the chains have mixed well.
+Two columns of this table are convergence diagnostics worth understanding.
 
-The trace plot tells the same story: the four chains overlap and look like stationary noise.
+* **`r_hat`** (the Gelman–Rubin statistic) compares the spread of the draws *within* each chain to the spread *between* chains. If the chains have all converged to the same distribution these two match and `r_hat` is close to $1.0$; values above roughly $1.01$ warn that the chains disagree and the draws cannot yet be trusted.
+
+* **`ess_bulk`** and **`ess_tail`** report the *effective sample size*. Because consecutive MCMC draws are correlated, a chain of length $N$ carries less information than $N$ independent draws would; the effective sample size estimates how many independent draws it is worth (in the bulk and in the tails of the distribution respectively). Larger is better.
+
+Here `r_hat` is essentially $1.0$ and the effective sample sizes run into the thousands, so the chains have mixed well.
+
+A **trace plot** gives a visual check of the same thing.
+
+ArviZ's `plot_trace` draws two panels for each parameter: on the right, the sampled value against the iteration number (one coloured line per chain); on the left, a density estimate of the draws from each chain.
+
+Well-mixed chains look like stationary noise on the right — a fuzzy, flat band, with the chains overlapping rather than drifting or wandering — and their densities on the left lie almost on top of one another.
 
 ```{code-cell} ipython3
 az.plot_trace(idata, var_names=["θ"])
 plt.tight_layout()
 plt.show()
 ```
+
+Our chains pass both checks, so we can trust the draws and turn to the posterior itself.
 
 Now we compare the MCMC posterior with the analytical beta posterior.
 


### PR DESCRIPTION
Two short pedagogical additions to `bayes_nonconj.md` for first-time readers.

## 1. What is NUTS?

A `{note}` where NUTS is introduced (the MCMC bullet in the Overview): NUTS is a form of **Hamiltonian Monte Carlo**, itself a **Metropolis–Hastings** method, whose proposals use **gradient (derivative) information** about the log-posterior and which **auto-tunes the trajectory length**. Links to <https://python-advanced.quantecon.org/mcmc.html> for an MH introduction.

## 2. Why variational inference?

A "Why variational inference?" subsection at the VI introduction, answering why we'd use VI when NUTS already gives accurate posteriors:

- **Scale** — MCMC evaluates the full-data likelihood every step and needs more steps as dimension grows; VI optimizes the ELBO with stochastic/mini-batch gradients (as in deep learning), so it scales to large datasets and high-dimensional models.
- Yields a cheap, reusable parametric approximation.
- **Cost:** accuracy — only the best fit within the guide family; can understate uncertainty.
- Closes with a rule of thumb for choosing MCMC vs VI.

Both are prose-only; no code changed. File still parses via jupytext and code cells are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)