### PR TITLE
Fix ar1_turningpts build: drop figsize from az.plot_trace

### DIFF
--- a/lectures/ar1_turningpts.md
+++ b/lectures/ar1_turningpts.md
@@ -328,7 +328,7 @@ def draw_from_posterior(sample):
 
     # check condition
     with AR1_model:
-        az.plot_trace(trace, figsize=(17, 6))
+        az.plot_trace(trace)
     
     rhos = trace.posterior.rho.values.flatten()
     sigmas = trace.posterior.sigma.values.flatten()


### PR DESCRIPTION
Closes #929.

`ar1_turningpts.md` calls `az.plot_trace(trace, figsize=(17, 6))`. Under **arviz 1.x** (the `arviz_plots` backend) `plot_trace` no longer accepts `figsize` and raises `ValueError`, failing notebook execution. It is latent on `main` only because the execution cache predates arviz 1.x.

**Fix:** drop the `figsize` kwarg (arviz uses its default size, also more consistent with the figure styleguide).

Verified against arviz 1.2.0 that `az.plot_trace(idata)` without `figsize`, and `trace.posterior.rho.values` attribute access, both still work — the `figsize` kwarg was the only problem. A repo-wide grep confirms this is the last remaining arviz plotting call passing `figsize` (the same fix in `ar1_bayes.md` is in #927).

🤖 Generated with [Claude Code](https://claude.com/claude-code)