### PR TITLE
[linkcheck] Clear residual false positives in weekly lychee report

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -44,9 +44,9 @@ jobs:
           args: >-
             --root-dir ${{ github.workspace }}
             --accept 200,202,403,503
-            --exclude-path genindex.html
-            --exclude-path search.html
-            --exclude-path prf-prf.html
+            --exclude-path 'genindex\.html$'
+            --exclude-path 'search\.html$'
+            --exclude-path 'prf-prf\.html$'
             --exclude '10\.3905/jod\.2012\.20\.1\.038'
             *.html
       - name: Create Issue From File

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,31 @@ jobs:
           # --root-dir resolves root-relative links (e.g. /_notebooks/*.ipynb,
           # /_pdf/quantecon-python.pdf) against the gh-pages checkout so they are
           # not reported as errors. See QuantEcon/lecture-python.myst#906.
-          args: --root-dir ${{ github.workspace }} --accept 200,403,503 *.html
+          #
+          # The flags below clear the residual false positives reported in
+          # QuantEcon/lecture-python.myst#933. Configuration is kept inline (rather
+          # than a lychee.toml) because lychee runs against the gh-pages checkout,
+          # which does not contain repo-root config files.
+          #   --accept 202        IEEE Xplore returns "202 Accepted" (anti-bot) for
+          #                       valid links, e.g. doi.org/10.1109/TAC.1977.1101561
+          #   --exclude-path ...  genindex / search / prf-prf are auto-generated
+          #                       utility pages with no source notebook, so the
+          #                       theme's "Download Notebook" button points at a
+          #                       nonexistent _notebooks/<page>.ipynb (and renders a
+          #                       second button with href="None"). They carry no
+          #                       unique content links, so skipping them loses no
+          #                       coverage.
+          #   --exclude <doi>     Journal of Derivatives DOI redirects into a
+          #                       login/paywall loop (exceeds max-redirects); the
+          #                       citation itself is valid.
+          args: >-
+            --root-dir ${{ github.workspace }}
+            --accept 200,202,403,503
+            --exclude-path genindex.html
+            --exclude-path search.html
+            --exclude-path prf-prf.html
+            --exclude '10\.3905/jod\.2012\.20\.1\.038'
+            *.html
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v6


### PR DESCRIPTION
## Summary

The weekly **Link Checker** action (lychee) filed #933 with **8 errors out of 24,997 links checked** (24,934 OK). I verified every one against the live `python.quantecon.org` site and the live URLs — none is a broken link in any lecture. They are all false positives or harmless theme artifacts on non-content pages, in two groups, both cleared here by tightening the lychee flags in `.github/workflows/linkcheck.yml`.

For context, the previous report (#906) had **241 errors** that were fixed by adding `--root-dir`; this PR clears the residual 8 so future weekly reports come back green and any non-empty report becomes a real signal rather than recurring noise.

## The 8 errors and how each is handled

| Page | Reported | Reality (verified) | Fix |
|---|---|---|---|
| `zreferences.html` | `10.1109/TAC.1977.1101561` → `[202]` | Resolves to IEEE Xplore, which returns `202 Accepted` (anti-bot) for a valid link | add `202` to `--accept` |
| `zreferences.html` | `10.3905/jod.2012.20.1.038` → `[302]` | Journal of Derivatives DOI redirects into a login/paywall loop (exceeds max-redirects); citation is valid | `--exclude` that DOI |
| `genindex.html` | `_notebooks/genindex.ipynb` + `None` | Auto-generated index page — no source notebook, so the theme's "Download Notebook" button points at a nonexistent `.ipynb` and renders a second `href="None"` | `--exclude-path` |
| `search.html` | `_notebooks/search.ipynb` + `None` | Auto-generated search page — same as above | `--exclude-path` |
| `prf-prf.html` | `_notebooks/prf-prf.ipynb` + `None` | Auto-generated proof index page — same as above | `--exclude-path` |

## Why inline `args` instead of a `lychee.toml`

The workflow checks out the built **`gh-pages`** site into the workspace and runs lychee there, so a `lychee.toml` committed to `main` would not be present in that checkout and would be silently ignored. (Worth a heads-up: `lecture-python-advanced.myst` keeps its `lychee.toml` on `main` while lychee runs against `gh-pages`, so that config may currently be inert — likely why its reports stay open. Happy to file a follow-up there.) Keeping the flags inline in the workflow `args` — which are read from the default branch at trigger time, independent of the gh-pages workspace — guarantees they are applied, consistent with the existing `--root-dir` / `--accept` flags.

## Verification / caveat

The link check only runs on a weekly schedule (or manual `workflow_dispatch`), so it cannot be exercised by ordinary PR CI. I validated that the workflow YAML parses and that the folded `args` collapse to the intended single command line. The change is a strict superset of the current working flags (adds `202` to accept plus the excludes), so it cannot regress existing coverage. Suggest a manual **Run workflow** dispatch after merge to confirm a clean, zero-error report.

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
