### PR TITLE
[house_auction] upgrade prettytable + wcwidth to fix wcwidth.width error

### DIFF
--- a/lectures/house_auction.md
+++ b/lectures/house_auction.md
@@ -17,7 +17,7 @@ kernelspec:
 ---
 tags: [hide-output]
 ---
-!pip install prettytable
+!pip install -U prettytable wcwidth
 ```
 
 ##  Overview


### PR DESCRIPTION
## What

Change `house_auction`'s install cell from `!pip install prettytable` to `!pip install -U prettytable wcwidth`.

## Why

`prettytable` 3.18.0 (released 2026-06-22) calls `wcwidth.width()` and requires `wcwidth>=0.3.5`, but the anaconda base ships `wcwidth` 0.2.13, which has no `.width`. The lecture's `!pip install prettytable` pulls 3.18.0 without upgrading `wcwidth`, so the cell `print(PrettyTable)` in `present_dict` fails on a full execution:

```
AttributeError: module 'wcwidth' has no attribute 'width'
```

This was surfaced by forced full builds on **both** anaconda 2025.12 and 2026.06, with the identical error — so it's an upstream `prettytable` break, independent of the recent anaconda bump (#923).

## Fix and verification

Adding `-U ... wcwidth` makes pip pull a `wcwidth` that has `.width` (0.8.1). Verified in an isolated venv — `prettytable` 3.18.0 + `wcwidth` 0.8.1, and a `PrettyTable` mimicking `present_dict` renders cleanly. The `preview` build on this PR also re-executes `house_auction` (its source changed), so it exercises the fix directly.

## Notes

- Part of #935 — this resolves the `house_auction` item; the arviz `plot_trace(figsize=)` items tracked there remain.
- Consistent with the base-anaconda model: this stays an unpinned in-lecture install, it just additionally keeps `wcwidth` current alongside `prettytable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
