### PR TITLE
[house_auction] Pin prettytable<3.18 for base-Anaconda wcwidth compatibility

### DIFF
--- a/lectures/house_auction.md
+++ b/lectures/house_auction.md
@@ -17,7 +17,7 @@ kernelspec:
 ---
 tags: [hide-output]
 ---
-!pip install -U prettytable wcwidth
+!pip install "prettytable<3.18"
 ```
 
 ##  Overview


### PR DESCRIPTION
Pins `house_auction`'s in-lecture install to `prettytable<3.18`, reverting the `!pip install -U prettytable wcwidth` from #937 (which does not actually fix the full-build failure — see below).

**The failure.** On a full `-W` cache build, `house_auction` fails with `AttributeError: module 'wcwidth' has no attribute 'width'`. `prettytable` 3.18.0 calls `wcwidth.width()` and requires `wcwidth>=0.3.5`, but base Anaconda (2026.06) ships `wcwidth` 0.2.14, which has no `.width`.

**Why #937's in-lecture upgrade can't work.** The Jupyter kernel imports `wcwidth` at startup (via IPython/ipykernel), so it is already cached in `sys.modules` as 0.2.14 before any cell runs. A runtime `!pip install -U wcwidth` upgrades the package on disk but does not reload the already-imported module in the running kernel — only a kernel restart would. #937 was verified in a clean venv (a fresh process, which naturally picks up the new `wcwidth`), which masked this. It also means a base-Anaconda reader running the notebook top-to-bottom hits the same failure, not just CI.

**The fix.** `prettytable` ≤ 3.17.0 depends only on `wcwidth` (unpinned) and works with base Anaconda's 0.2.14, so pinning `<3.18` removes the need for any `wcwidth` upgrade. This keeps the lecture runnable in base Anaconda — pinning `wcwidth` in `environment.yml` instead would only green CI while leaving a base-Anaconda reader broken.

**Follow-up.** Tracked in #938: drop the `<3.18` pin and return to the latest `prettytable` once a base Anaconda release ships `wcwidth>=0.3.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
