### PR TITLE
[kalman_filter_var] Add missing quantecon install cell

### DIFF
--- a/lectures/kalman_filter_var.md
+++ b/lectures/kalman_filter_var.md
@@ -19,6 +19,14 @@ kernelspec:
 ```{index} single: Vector Autoregression; and Kalman filter
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install quantecon
+```
+
 ## Overview
 
 This lecture derives the **Kalman filter** for a linear Gaussian state space system


### PR DESCRIPTION
## What

Adds the standard `!pip install quantecon` cell to `lectures/kalman_filter_var.md`, matching the convention in `kalman.md` and `kalman_2.md`.

## Why

The `publish-2026jul06` run [failed](https://github.com/QuantEcon/lecture-python.myst/actions/runs/28833512654/job/85512329203) at the **Build PDF from LaTeX** step with:

`ModuleNotFoundError: No module named 'quantecon'`

`kalman_filter_var` imports `quantecon` but was the only quantecon-using lecture without an install cell. The bug has been latent since the lecture was added in #931, hidden by two effects:

- **Cross-lecture env pollution** — in a full build (PR CI, weekly cache builds) other lectures run their own `!pip install quantecon` first, so by the time this notebook executes the package already happens to be present. `environment.yml` never ships `quantecon`; it only ever arrives via in-lecture pip installs.
- **The publish job ran it in isolation** — #944 rewrote this lecture (~781 lines) and invalidated its jupyter-cache entry, but the publish job downloads the build cache from the pre-#944 run. So `kalman_filter_var` was effectively the only notebook re-executed, in a fresh env where nothing had installed `quantecon`, and the import failed immediately — taking down HTML, notebook, and gh-pages deploy along with it.

## Fix

Add the standard hide-output install block. After merge, push a fresh `publish*` tag to re-run the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)