### PR TITLE
Bump quantecon/actions/publish-gh-pages to v0.8.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
           path: _build/html/reports
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: quantecon/actions/publish-gh-pages@v0.6.0
+        uses: quantecon/actions/publish-gh-pages@v0.8.0
         with:
           build-dir: _build/html
           cname: python.quantecon.org


### PR DESCRIPTION
Bumps `quantecon/actions/publish-gh-pages` from `v0.6.0` to `v0.8.0` (current release), aligning it with `preview-netlify`, which is already on `v0.8.0` in `ci.yml` — this repo had drifted into an internally inconsistent mix. Part of the cross-repo audit in QuantEcon/lectures#11.

## Why

`v0.6.0` is two minor releases behind. `v0.8.0` brings robustness fixes to `publish-gh-pages`: the release tarball is written to `$RUNNER_TEMP` so it can't recurse into itself, and release-asset creation skips cleanly off-tag and fails fast on a missing token.

## Impact — drop-in, no behavioral change here

- The `publish-gh-pages` input interface is byte-for-byte identical between v0.6.0 and v0.8.0 — no new required inputs, nothing renamed.
- This workflow's call site is unchanged; it passes `github-token` and runs only on `push: tags: 'publish*'`, so the new off-tag / missing-token guards are no-ops.
- No `ci.yml` / `cache.yml` changes are needed — only the tag-triggered deploy path is touched.

The one real-world check is the next `publish*` tag on this repo after merge.

References: [v0.8.0 release](https://github.com/QuantEcon/actions/releases/tag/v0.8.0) · [v0.6.0…v0.8.0 diff](https://github.com/QuantEcon/actions/compare/v0.6.0...v0.8.0)
