### PR TITLE
[mccall_q.md] Update np.random → Generator API

### DIFF
--- a/lectures/mccall_q.md
+++ b/lectures/mccall_q.md
@@ -79,7 +79,7 @@ from quantecon.distributions import BetaBinomial
 
 import matplotlib.pyplot as plt
 
-np.random.seed(123)
+rng = np.random.default_rng(123)
 ```
 
 ## Review of McCall Model
@@ -514,15 +514,15 @@ class Qlearning_McCall:
         self.quit_allowed = quit_allowed
 
 
-    def draw_offer_index(self):
+    def draw_offer_index(self, rng):
         """
         Draw a state index from the wage distribution.
         """
 
         q = self.q
-        return np.searchsorted(np.cumsum(q), np.random.random(), side="right")
+        return np.searchsorted(np.cumsum(q), rng.random(), side="right")
 
-    def temp_diff(self, qtable, state, accept):
+    def temp_diff(self, qtable, state, accept, rng):
         """
         Compute the TD associated with state and action.
         """
@@ -530,7 +530,7 @@ class Qlearning_McCall:
         c, β, w = self.c, self.β, self.w
 
         if accept==0:
-            state_next = self.draw_offer_index()
+            state_next = self.draw_offer_index(rng)
             TD = c + β*np.max(qtable[state_next, :]) - qtable[state, accept]
         else:
             state_next = state
@@ -541,7 +541,7 @@ class Qlearning_McCall:
 
         return TD, state_next
 
-    def run_one_epoch(self, qtable, max_times=20000):
+    def run_one_epoch(self, qtable, rng, max_times=20000):
         """
         Run an "epoch".
         """
@@ -549,7 +549,7 @@ class Qlearning_McCall:
         c, β, w = self.c, self.β, self.w
         eps, δ, lr, T = self.eps, self.δ, self.lr, self.T
 
-        s0 = self.draw_offer_index()
+        s0 = self.draw_offer_index(rng)
         s = s0
         accept_count = 0
 
@@ -557,7 +557,7 @@ class Qlearning_McCall:
 
             # choose action
             accept = np.argmax(qtable[s, :])
-            if np.random.random()<=eps:
+            if rng.random()<=eps:
                 accept = 1 - accept
 
             if accept == 1:
@@ -565,7 +565,7 @@ class Qlearning_McCall:
             else:
                 accept_count = 0
 
-            TD, s_next = self.temp_diff(qtable, s, accept)
+            TD, s_next = self.temp_diff(qtable, s, accept, rng)
 
             # update qtable
             qtable_new = qtable.copy()
@@ -582,7 +582,7 @@ class Qlearning_McCall:
         return qtable_new
 
 @jit
-def run_epochs(N, qlmc, qtable):
+def run_epochs(N, qlmc, qtable, rng):
     """
     Run epochs N times with qtable from the last iteration each time.
     """
@@ -590,7 +590,7 @@ def run_epochs(N, qlmc, qtable):
     for n in range(N):
         if n%(N/10)==0:
             print(f"Progress: EPOCHs = {n}")
-        new_qtable = qlmc.run_one_epoch(qtable)
+        new_qtable = qlmc.run_one_epoch(qtable, rng)
         qtable = new_qtable
 
     return qtable
@@ -608,7 +608,7 @@ qlmc = Qlearning_McCall()
 
 # run
 qtable0 = np.zeros((len(w_default), 2))
-qtable = run_epochs(20000, qlmc, qtable0)
+qtable = run_epochs(20000, qlmc, qtable0, rng)
 ```
 
 ```{code-cell} ipython3
@@ -685,7 +685,7 @@ def plot_epochs(epochs_to_plot, quit_allowed=1):
             ax.plot(w_new, valfunc_qlr, '-o', label=f'QL:epochs={n}, mean error={error}')
 
 
-        new_qtable = qlmc_new.run_one_epoch(qtable)
+        new_qtable = qlmc_new.run_one_epoch(qtable, rng)
         qtable = new_qtable
 
     ax.set_xlabel('wages')


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `mccall_q.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

`np.random.seed(123)` is replaced by an explicit `rng = np.random.default_rng(123)` (keeping the original fixed seed), and the `np.random.random()` calls inside the `Qlearning_McCall` jitclass are migrated to `rng.random()`. Following the style guide for jitclass code, `rng` is passed in as a method argument rather than stored as a class attribute, and threaded through `run_epochs` and its call sites. The notebook executes successfully under Numba.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
