### PR TITLE
[two_auctions.md] Update np.random → Generator API

### DIFF
--- a/lectures/two_auctions.md
+++ b/lectures/two_auctions.md
@@ -201,7 +201,7 @@ plt.rcParams.update({"text.usetex": True, 'font.size': 14})
 colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
 
 # ensure the notebook generates the same randomness
-np.random.seed(1337)
+rng = np.random.default_rng(1337)
 ```
 
 We repeat an auction with 5 bidders for 100,000 times.
@@ -212,7 +212,7 @@ The valuations of each bidder is distributed $U(0,1)$.
 N = 5
 R = 100_000
 
-v = np.random.uniform(0, 1, (N, R))
+v = rng.uniform(0, 1, (N, R))
 
 # BNE in first-price sealed bid
 
@@ -431,7 +431,7 @@ v_grid = np.linspace(0.3, 1, 8)
 bid_analytical = b_star(v_grid, N)
 
 # Redraw valuations
-v = np.random.uniform(0, 1, (N, R))
+v = rng.uniform(0, 1, (N, R))
 bid_simulated = [evaluate_largest(ii, v) for ii in v_grid]
 
 fig, ax = plt.subplots(figsize=(6, 4))
@@ -453,8 +453,8 @@ Let's try an example in which the distribution of private values is a $\chi^2$ d
 We'll start by taking a look at a $\chi^2$ distribution with the help of the following Python code:
 
 ```{code-cell} ipython3
-np.random.seed(1337)
-v = np.random.chisquare(df=2, size=(N * R,))
+rng = np.random.default_rng(1337)
+v = rng.chisquare(df=2, size=(N * R,))
 
 plt.hist(v, bins=50, edgecolor='w')
 plt.xlabel('Values: $v$')
@@ -464,8 +464,8 @@ plt.show()
 Now we'll get Python to construct a bid price function
 
 ```{code-cell} ipython3
-np.random.seed(1337)
-v = np.random.chisquare(df=2, size=(N, R))
+rng = np.random.default_rng(1337)
+v = rng.chisquare(df=2, size=(N, R))
 
 # we compute the quantile of v as our grid
 pct_quantile = np.linspace(0, 100, 101)[1:-1]
@@ -663,8 +663,8 @@ class bid_price_solution:
 ```
 
 ```{code-cell} ipython3
-np.random.seed(1337)
-v = np.random.chisquare(df=2, size=(N, R))
+rng = np.random.default_rng(1337)
+v = rng.chisquare(df=2, size=(N, R))
 
 chi_squ_case = bid_price_solution(v)
 ```


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `two_auctions.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The `np.random.seed(1337)` / `np.random.uniform(...)` / `np.random.chisquare(...)` calls are replaced with an explicit `rng = np.random.default_rng(1337)` and the corresponding `rng.uniform(...)` / `rng.chisquare(...)` methods. The lecture intentionally re-seeds to reproduce the same valuations across blocks, so `rng` is re-created with the same seed at those points, preserving the original reproducibility. There are no Numba-related concerns in this file.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
