### PR TITLE
[optgrowth_fast/ogm.py] Update np.random → Generator API

### DIFF
--- a/lectures/_static/lecture_specific/optgrowth_fast/ogm.py
+++ b/lectures/_static/lecture_specific/optgrowth_fast/ogm.py
@@ -14,23 +14,22 @@ opt_growth_data = [
 class OptimalGrowthModel:
 
     def __init__(self,
+                rng,
                 α=0.4,
                 β=0.96,
                 μ=0,
                 s=0.1,
                 grid_max=4,
                 grid_size=120,
-                shock_size=250,
-                seed=1234):
+                shock_size=250):
 
         self.α, self.β, self.μ, self.s = α, β, μ, s
 
         # Set up grid
         self.grid = np.linspace(1e-5, grid_max, grid_size)
 
-        # Store shocks (with a seed, so results are reproducible)
-        np.random.seed(seed)
-        self.shocks = np.exp(μ + s * np.random.randn(shock_size))
+        # Store shocks (drawn from the passed-in rng, so results are reproducible)
+        self.shocks = np.exp(μ + s * rng.standard_normal(shock_size))
 
 
     def f(self, k):


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `_static/lecture_specific/optgrowth_fast/ogm.py` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299). The legacy global random-state calls are replaced with an explicit `np.random.default_rng()` generator.

## Details

- The random draw sits inside the `@jitclass` `OptimalGrowthModel.__init__`. Following the QuantEcon jitclass convention, `rng` is passed in as an argument (not stored as a class attribute), and `np.random.seed(seed)` / `np.random.randn(shock_size)` are replaced with `rng.standard_normal(shock_size)`.
- The `seed` parameter is dropped from the constructor; reproducibility now comes from the caller creating `rng = np.random.default_rng(seed)` and passing it in. This changes the `__init__` signature (`rng` added, `seed` removed), so call sites must construct with `OptimalGrowthModel(rng)`.
- Within this repository, no lecture appears to `:load:`/reference `optgrowth_fast/ogm.py`, so there are no in-repo call sites to update here. Any external call sites (e.g. in other lecture repos) will need to construct `rng` and pass it in.
- Verified locally that the sized `rng.standard_normal(shock_size)` call and passing a `Generator` into the `@jitclass` compile, run, and remain reproducible under Numba 0.62.1.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
