### PR TITLE
[optgrowth_fast/ogm_crra.py] Update np.random → Generator API

### DIFF
--- a/lectures/_static/lecture_specific/optgrowth_fast/ogm_crra.py
+++ b/lectures/_static/lecture_specific/optgrowth_fast/ogm_crra.py
@@ -15,6 +15,7 @@ opt_growth_data = [
 class OptimalGrowthModel_CRRA:
 
     def __init__(self,
+                rng,
                 α=0.4,
                 β=0.96,
                 μ=0,
@@ -22,17 +23,15 @@ class OptimalGrowthModel_CRRA:
                 γ=1.5,
                 grid_max=4,
                 grid_size=120,
-                shock_size=250,
-                seed=1234):
+                shock_size=250):
 
         self.α, self.β, self.γ, self.μ, self.s = α, β, γ, μ, s
 
         # Set up grid
         self.grid = np.linspace(1e-5, grid_max, grid_size)
 
-        # Store shocks (with a seed, so results are reproducible)
-        np.random.seed(seed)
-        self.shocks = np.exp(μ + s * np.random.randn(shock_size))
+        # Store shocks (drawn from the passed-in rng, so results are reproducible)
+        self.shocks = np.exp(μ + s * rng.standard_normal(shock_size))
 
 
     def f(self, k):


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `_static/lecture_specific/optgrowth_fast/ogm_crra.py` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299). The legacy global random-state calls are replaced with an explicit `np.random.default_rng()` generator.

## Details

- The random draw sits inside the `@jitclass` `OptimalGrowthModel_CRRA.__init__`. Following the QuantEcon jitclass convention, `rng` is passed in as an argument (not stored as a class attribute), and `np.random.seed(seed)` / `np.random.randn(shock_size)` are replaced with `rng.standard_normal(shock_size)`.
- The `seed` parameter is dropped from the constructor; reproducibility now comes from the caller creating `rng = np.random.default_rng(seed)` and passing it in. This changes the `__init__` signature (`rng` added, `seed` removed), so call sites must construct with `OptimalGrowthModel_CRRA(rng)`.
- Within this repository, no lecture appears to `:load:`/reference `optgrowth_fast/ogm_crra.py`, so there are no in-repo call sites to update here. Any external call sites (e.g. in other lecture repos) will need to construct `rng` and pass it in.
- Verified locally that the sized `rng.standard_normal(shock_size)` call and passing a `Generator` into the `@jitclass` compile, run, and remain reproducible under Numba 0.62.1 (the same pattern was checked in the companion `ogm.py` PR).

## Note for reviewers

While migrating I noticed a pre-existing bug unrelated to this change: `u_prime_inv` is defined as `def u_prime_inv(c):` (missing `self`) yet its body references `self.γ`, so calling it would raise `NameError`. I have left it untouched to keep this PR focused on the random API migration, but I'm happy to fix it here (or in a separate PR) if you'd prefer — just let me know.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
