### PR TITLE
Repoint ols data reads to this repo's own copies

### DIFF
--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -91,7 +91,7 @@ These variables and other data used in the paper are available for download on D
 We will use pandas' `.read_stata()` function to read in data contained in the `.dta` files to dataframes
 
 ```{code-cell} python3
-df1 = pd.read_stata('https://github.com/QuantEcon/lecture-python/blob/master/source/_static/lecture_specific/ols/maketable1.dta?raw=true')
+df1 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable1.dta')
 df1.head()
 ```
 
@@ -323,7 +323,7 @@ Let's estimate some of the extended models considered in the paper
 (Table 2) using data from `maketable2.dta`
 
 ```{code-cell} python3
-df2 = pd.read_stata('https://github.com/QuantEcon/lecture-python/blob/master/source/_static/lecture_specific/ols/maketable2.dta?raw=true')
+df2 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable2.dta')
 
 # Add constant term to dataset
 df2['const'] = 1
@@ -475,7 +475,7 @@ used for estimation)
 
 ```{code-cell} python3
 # Import and select the data
-df4 = pd.read_stata('https://github.com/QuantEcon/lecture-python/blob/master/source/_static/lecture_specific/ols/maketable4.dta?raw=true')
+df4 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable4.dta')
 df4 = df4[df4['baseco'] == 1]
 
 # Add a constant variable


### PR DESCRIPTION
The three data reads in the body of `ols.md` (`maketable1`, `maketable2`, `maketable4`) still fetched from the retired `QuantEcon/lecture-python` repo via `blob/master/…?raw=true`, leaving this lecture dependent on a repo the series no longer maintains. Identical copies are already committed under `lectures/_static/lecture_specific/ols/` — and are already what the **solutions** in this same lecture read. This points the body at them too, using the same URL form the solutions use.

## Verification

Byte-compare before repointing, so this cannot change lecture output:

| File | own-repo copy | legacy repo | new URL serves |
| --- | --- | --- | --- |
| `maketable1.dta` | `7a8687cc…` | `7a8687cc…` | `7a8687cc…` |
| `maketable2.dta` | `7f0dc30d…` | `7f0dc30d…` | `7f0dc30d…` |
| `maketable4.dta` | `2b34cce2…` | `2b34cce2…` | `2b34cce2…` |

All three sha256 sums are identical across all three columns. Also confirmed `pd.read_stata()` parses each of the new URLs — 163 rows each, expected columns present — so this is verified against the real fetch path, not just an HTTP status check.

## Scope

This is the `ols` half of the legacy-reference cleanup in QuantEcon/meta#337. The remaining `pandas_panel` references are deliberately left alone: those files are migrating to `QuantEcon/data-lectures` as pilot P2 (QuantEcon/meta#338), so an interim repoint here would be churn.

Part of QuantEcon/meta#337
See QuantEcon/meta#336