### PR TITLE
Retire the last references to the retired lecture-python repo

### DIFF
--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -65,7 +65,7 @@ countries and assign it to `realwage`.
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url1 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python/master/source/_static/lecture_specific/pandas_panel/realwage.csv'
+url1 = 'https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/realwage.csv'
 ```
 
 ```{code-cell} ipython3
@@ -185,7 +185,7 @@ function.
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url2 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python/master/source/_static/lecture_specific/pandas_panel/countries.csv'
+url2 = 'https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/countries.csv'
 ```
 
 ```{code-cell} ipython3

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -64,7 +64,7 @@ touch.
 
 ## Reporting an Issue
 
-One way to give feedback is to raise an issue through our [issue tracker](https://github.com/QuantEcon/lecture-python/issues).
+One way to give feedback is to raise an issue through our [issue tracker](https://github.com/QuantEcon/lecture-python.myst/issues).
 
 Please be as specific as possible.  Tell us where the problem is and as much
 detail about your local set up as you can provide.


### PR DESCRIPTION
After this, **nothing in this repo references `QuantEcon/lecture-python` any more** — the repo it was migrated from, last touched **2022-01-21**. Follows QuantEcon/lecture-python.myst#966, which did the `ols` half.

## `pandas_panel` — two of three reads were still remote

The lecture read `realwage.csv` and `countries.csv` from the retired repo while reading `employ.csv` — the third file of the same trio, in the same lecture — from **this repo's own copy**. All three copies are already committed under `_static/lecture_specific/pandas_panel/`, so two of the reads were reaching for a four-year-dead repo for no reason. Now all three are consistent and use the same URL form.

## `troubleshooting` — sent readers to the wrong issue tracker

It asked readers to report problems with *this* lecture series by opening an issue on `QuantEcon/lecture-python` — which still has issues enabled, so reports would land in a repo nobody watches. Repointed at this repo's tracker, matching the sibling lecture repos.

## Verification

| File | own-repo copy | legacy repo | new URL serves |
| --- | --- | --- | --- |
| `realwage.csv` | identical | identical | identical |
| `countries.csv` | identical | identical | identical |
| `employ.csv` | identical | identical | identical |

sha256-compared before repointing, so lecture output cannot change. All three also confirmed readable over https from the new URLs.

## This is deliberately interim — and it costs P2 nothing

The plan in QuantEcon/workspace-lectures#14 says to skip `pandas_panel` because pilot P2 (QuantEcon/meta#338) migrates this trio to `QuantEcon/data-lectures`, making an interim repoint churn. That reasoning is sound but the arithmetic changed:

- **P2 rewrites these three lines regardless** of whether they say "legacy" or "own-repo" today, so this adds no work to it.
- **P2 got materially further away.** It was scoped as 2 repos / 5 references; an audit today found the `pandas_panel` trio is consumed by **6 source repos / 17 references** — the translations (`lecture-python.zh-cn`, `lecture-python-programming.{fa,fr,zh-cn}`) each carry their own copy of the lecture and were never counted.
- Meanwhile the dependency is a real one on an unmaintained repo. That is the same shape as the bug QuantEcon/meta#337 risk 1 just cost us: a data URL nobody was watching, which broke the moment its target moved.

Happy to close this and wait for P2 if you'd rather hold the line on the original plan — it is two lines either way.

Part of QuantEcon/meta#337
See QuantEcon/meta#336
