### PR TITLE
Use vendored data in Hansen-Singleton lectures

### DIFF
--- a/lectures/hansen_singleton_1982.md
+++ b/lectures/hansen_singleton_1982.md
@@ -985,19 +985,18 @@ Because the Ken French return is not identical to the original CRSP NYSE value-w
 
 Both this lecture and the companion lecture {doc}`hansen_singleton_1983` use the same data construction.
 
-The hidden cell below loads a vendored monthly dataset of gross real returns and gross consumption growth. The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`_static/lecture_specific/hansen_singleton_1982/make_data.py`](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_static/lecture_specific/hansen_singleton_1982/make_data.py) and read here directly from GitHub.
+The hidden cell below loads a vendored monthly dataset of gross real returns and gross consumption growth. The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`_static/lecture_specific/hansen_singleton_1982/make_data.py`](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_static/lecture_specific/hansen_singleton_1982/make_data.py) and read here from the checked-out copy.
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
 
-DATA_URL = (
-    "https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/"
-    "lectures/_static/lecture_specific/hansen_singleton_1982/"
+DATA_PATH = (
+    "_static/lecture_specific/hansen_singleton_1982/"
     "hansen_singleton_1982_data.csv"
 )
 
 # Read the vendored snapshot once; load_hs_monthly_data just slices it.
-_data = pd.read_csv(DATA_URL, index_col=0, parse_dates=True)
+_data = pd.read_csv(DATA_PATH, index_col=0, parse_dates=True)
 
 
 def load_hs_monthly_data(start="1959-02-01", end="1978-12-01"):

--- a/lectures/hansen_singleton_1983.md
+++ b/lectures/hansen_singleton_1983.md
@@ -1425,19 +1425,18 @@ While Hansen-Singleton use CRSP value-weighted NYSE returns, we use the Ken Fren
 
 The consumption series is constructed from consumption of nondurables (`ND`) with the nondurables deflator.
 
-The hidden cell below loads a vendored monthly dataset of returns and consumption series. The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`_static/lecture_specific/hansen_singleton_1983/make_data.py`](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_static/lecture_specific/hansen_singleton_1983/make_data.py) and read here directly from GitHub.
+The hidden cell below loads a vendored monthly dataset of returns and consumption series. The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`_static/lecture_specific/hansen_singleton_1983/make_data.py`](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_static/lecture_specific/hansen_singleton_1983/make_data.py) and read here from the checked-out copy.
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
 
-DATA_URL = (
-    "https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/"
-    "lectures/_static/lecture_specific/hansen_singleton_1983/"
+DATA_PATH = (
+    "_static/lecture_specific/hansen_singleton_1983/"
     "hansen_singleton_1983_data.csv"
 )
 
 # Read the vendored snapshot once; load_hs_monthly_data just slices it.
-_data = pd.read_csv(DATA_URL, index_col=0, parse_dates=True)
+_data = pd.read_csv(DATA_PATH, index_col=0, parse_dates=True)
 
 
 def load_hs_monthly_data(start="1959-02-01", end="1978-12-01"):


### PR DESCRIPTION
## Summary
- read both Hansen-Singleton datasets from their vendored `_static/lecture_specific` paths
- update the surrounding prose to describe the checked-out data source
- remove runtime dependence on raw GitHub URLs

Closes QuantEcon/actions#102

## Validation
- pandas smoke checks: 1982 data `(239, 2)` and 1983 data `(239, 5)`, with expected columns and DatetimeIndex
- executed and built `hansen_singleton_1982` successfully (all cells, HTML)
- executed and built `hansen_singleton_1983` successfully (all cells, HTML)
- git diff --check passes