### PR TITLE
[perm_income.md] Update np.random → Generator API

### DIFF
--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -479,8 +479,8 @@ r = 0.05
 T = 60
 
 @jit
-def time_path(T):
-    w = np.random.randn(T+1)  # w_0, w_1, ..., w_T
+def time_path(T, rng):
+    w = rng.standard_normal(T+1)  # w_0, w_1, ..., w_T
     w[0] = 0
     b = np.zeros(T+1)
     for t in range(1, T+1):
@@ -489,7 +489,8 @@ def time_path(T):
     c = μ + (1 - β) * (σ * w - b)
     return w, b, c
 
-w, b, c = time_path(T)
+rng = np.random.default_rng()
+w, b, c = time_path(T, rng)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 
@@ -512,7 +513,7 @@ fig, ax = plt.subplots(figsize=(10, 6))
 
 b_sum = np.zeros(T+1)
 for i in range(250):
-    w, b, c = time_path(T)  # Generate new time path
+    w, b, c = time_path(T, rng)  # Generate new time path
     rcolor = random.choice(('c', 'g', 'b', 'k'))
     ax.plot(c, color=rcolor, lw=0.8, alpha=0.7)
 


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `perm_income.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

## Details

- Replaced `np.random.randn(T+1)` in the `@jit`-decorated `time_path` with `rng.standard_normal(T+1)`, passing `rng` in as an argument (`time_path(T, rng)`).
- Added `rng = np.random.default_rng()` near the first use and updated both call sites to pass `rng`.
- No fixed seed was introduced, so simulation behaviour is unchanged.

Note: `time_path` is jitted but has no `parallel=True`/`prange`, so `rng` is passed in as an argument per the style guide. Verified locally that this compiles and runs under Numba.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
