### PR TITLE
Add zh-cn translation sync workflow (Phase 0 Track B)

### DIFF
--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -1,0 +1,35 @@
+# Sync Translations — Simplified Chinese
+# On merged PR, translate changed lectures into the zh-cn target repo.
+# Comment \translate-resync on a merged PR to re-trigger sync.
+name: Sync Translations (Simplified Chinese)
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+      - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0
+        with:
+          mode: sync
+          target-repo: QuantEcon/lecture-python.zh-cn
+          target-language: zh-cn
+          source-language: en
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -14,10 +14,21 @@ on:
 
 jobs:
   sync:
+    # The issue_comment path requires: a comment on a PR (not a bare issue), the
+    # resync command, and a trusted author — anyone else could otherwise fire a
+    # secrets-bearing run (Anthropic spend + PAT) from any comment.
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '\translate-resync') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
+
+    # The action authenticates with QUANTECON_SERVICES_PAT; the ambient
+    # GITHUB_TOKEN is unused beyond checkout, so keep it read-only.
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Part of #947. Wires this repo as the English source for QuantEcon/lecture-python.zh-cn: on each merged lecture PR (or a `\translate-resync` comment) the action translates the changed lectures and opens a PR in the target repo. Copied from lecture-python-intro's proven workflow with only the target-repo changed; pins `QuantEcon/action-translation@v0`.

**Secrets**: ANTHROPIC_API_KEY and QUANTECON_SERVICES_PAT are already org-visible to this repo (verified 2026-07-18).

**Decision note for merge time**: 42 of 121 lectures have no translation yet. Once this workflow is live, a merged source PR touching an untranslated lecture will open a *new-translation* PR in the target — effectively incremental Phase 2 without a restarted review campaign. If that is not wanted yet, hold this PR until the campaign scoping (see the Track B editor report in project-translation) is settled, or merge and triage new-file PRs as they appear; each arrives as a reviewable PR either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)