### PR TITLE
[wealth_dynamics.md] Update np.random → Generator API

### DIFF
--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -96,8 +96,9 @@ The package [QuantEcon.py](https://github.com/QuantEcon/QuantEcon.py), already i
 To illustrate, suppose that
 
 ```{code-cell} ipython3
+rng = np.random.default_rng()
 n = 10_000                      # size of sample
-w = np.exp(np.random.randn(n))  # lognormal draws
+w = np.exp(rng.standard_normal(n))  # lognormal draws
 ```
 
 is data representing the wealth of 10,000 households.
@@ -137,7 +138,7 @@ a_vals = (1, 2, 5)              # Pareto tail index
 n = 10_000                      # size of each sample
 fig, ax = plt.subplots()
 for a in a_vals:
-    u = np.random.uniform(size=n)
+    u = rng.uniform(size=n)
     y = u**(-1/a)               # distributed as Pareto with tail index a
     f_vals, l_vals = qe.lorenz_curve(y)
     ax.plot(f_vals, l_vals, label=f'$a = {a}$')
@@ -177,7 +178,7 @@ n = 100
 
 fig, ax = plt.subplots()
 for a in a_vals:
-    y = np.random.weibull(a, size=n)
+    y = rng.weibull(a, size=n)
     ginis.append(qe.gini_coefficient(y))
     ginis_theoretical.append(1 - 2**(-1/a))
 ax.plot(a_vals, ginis, label='estimated gini coefficient')
@@ -561,13 +562,14 @@ Here is one solution, which produces a good match between theory and
 simulation.
 
 ```{code-cell} ipython3
+rng = np.random.default_rng()
 a_vals = np.linspace(1, 10, 25)  # Pareto tail index
 ginis = np.empty_like(a_vals)
 
 n = 1000                         # size of each sample
 fig, ax = plt.subplots()
 for i, a in enumerate(a_vals):
-    y = np.random.uniform(size=n)**(-1/a)
+    y = rng.uniform(size=n)**(-1/a)
     ginis[i] = qe.gini_coefficient(y)
 ax.plot(a_vals, ginis, label='sampled')
 ax.plot(a_vals, 1/(2*a_vals - 1), label='theoretical')


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `wealth_dynamics.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The migration is limited to the ordinary-Python code cells. The code around `update_cross_section` is intentionally left unchanged — see Details.

## Related PRs and issues

Before opening this PR I surveyed open PRs and issues touching this lecture:

- **Open PRs:** no other open PR touches `wealth_dynamics.md`.
- **Already merged into `main`** (reflected in this branch): [#574](https://github.com/QuantEcon/lecture-python.myst/pull/574), [#581](https://github.com/QuantEcon/lecture-python.myst/pull/581).
- **Closed without merging** (earlier style-guide / JAX-conversion attempts): [#513](https://github.com/QuantEcon/lecture-python.myst/pull/513), [#626](https://github.com/QuantEcon/lecture-python.myst/pull/626), [#628](https://github.com/QuantEcon/lecture-python.myst/pull/628), [#630](https://github.com/QuantEcon/lecture-python.myst/pull/630), [#632](https://github.com/QuantEcon/lecture-python.myst/pull/632), [#634](https://github.com/QuantEcon/lecture-python.myst/pull/634), [#636](https://github.com/QuantEcon/lecture-python.myst/pull/636), [#638](https://github.com/QuantEcon/lecture-python.myst/pull/638), [#639](https://github.com/QuantEcon/lecture-python.myst/pull/639).
- **Related open issue:** [#970](https://github.com/QuantEcon/lecture-python.myst/issues/970) — random seed in the parallel `update_cross_section` code; deliberately left for a follow-up (see Details).
- **An unrelated issue that still touches this lecture:** [#512](https://github.com/QuantEcon/lecture-python.myst/issues/512) — a title-formatting tracking issue.

## Details

In the plain Python cells, `np.random.*` calls are replaced with an explicit `rng = np.random.default_rng()`. `rng` is defined at its first use in the main text and reused afterwards; the `wd_ex1` solution block defines its own `rng` to stay self-contained. No fixed seed is introduced.

**Code around `update_cross_section` left unchanged (deliberate).** While reviewing this file I found the pre-existing issue [#970](https://github.com/QuantEcon/lecture-python.myst/issues/970) ("Add random seed to wealth dynamics lecture"). It concerns `update_cross_section`, which is `@jit(parallel=True)` and draws unseeded `np.random.randn()` inside a `prange` loop, causing the Gini-vs-`μ_r` figure to change on every rebuild. Since that discussion is still open, I've deliberately left that code — and the related code that depends on it — untouched in this PR:

- `update_cross_section` draws inside a `prange` loop, where Numba's Generator support is not thread-safe.
- `update_states` is used by both the parallel `update_cross_section` and the non-parallel `wealth_time_series`, so it cannot be migrated on its own.
- Because of this, migrating only the initial draw in `wealth_time_series` (line ~368) would leave the per-period shocks (drawn via `update_states`) on the legacy global `np.random` state, mixing two RNG sources within a single simulation — inconsistent, and it would not actually remove the hidden global state from that code path.

If you'd like, I'm happy to handle this `update_cross_section` code (RNG migration and/or the [#970](https://github.com/QuantEcon/lecture-python.myst/issues/970) reproducibility fix) in a separate follow-up — just let me know how you'd prefer to proceed.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
