### PR TITLE
[likelihood_ratio_process_2.md] Update np.random → Generator API

### DIFF
--- a/lectures/likelihood_ratio_process_2.md
+++ b/lectures/likelihood_ratio_process_2.md
@@ -63,6 +63,8 @@ import numpy as np
 from numba import vectorize, jit, prange
 from math import gamma
 from scipy.integrate import quad
+
+rng = np.random.default_rng()
 ```
 
 ## Review: likelihood ratio processes
@@ -150,7 +152,7 @@ g = jit(lambda x: p(x, G_a, G_b))
 
 ```{code-cell} ipython3
 @jit
-def simulate(a, b, T=50, N=500):
+def simulate(a, b, rng, T=50, N=500):
     '''
     Generate N sets of T observations of the likelihood ratio,
     return as N x T matrix.
@@ -160,7 +162,7 @@ def simulate(a, b, T=50, N=500):
 
     for i in range(N):
         for j in range(T):
-            w = np.random.beta(a, b)
+            w = rng.beta(a, b)
             l_arr[i, j] = f(w) / g(w)
 
     return l_arr
@@ -614,14 +616,14 @@ T = 100
 N = 10000
 
 # Nature follows f, g, or mixture
-s_seq_f = np.random.beta(F_a, F_b, (N, T))
-s_seq_g = np.random.beta(G_a, G_b, (N, T))
+s_seq_f = rng.beta(F_a, F_b, (N, T))
+s_seq_g = rng.beta(G_a, G_b, (N, T))
 
 h = jit(lambda x: 0.5 * f(x) + 0.5 * g(x))
-model_choices = np.random.rand(N, T) < 0.5
+model_choices = rng.random((N, T)) < 0.5
 s_seq_h = np.empty((N, T))
-s_seq_h[model_choices] = np.random.beta(F_a, F_b, size=model_choices.sum())
-s_seq_h[~model_choices] = np.random.beta(G_a, G_b, size=(~model_choices).sum())
+s_seq_h[model_choices] = rng.beta(F_a, F_b, size=model_choices.sum())
+s_seq_h[~model_choices] = rng.beta(G_a, G_b, size=(~model_choices).sum())
 
 l_cum_f, c1_f = simulate_blume_easley(s_seq_f)
 l_cum_g, c1_g = simulate_blume_easley(s_seq_g)
@@ -770,7 +772,7 @@ for row, (f_belief, g_belief, label) in enumerate([
     
     for col, nature_label in enumerate(nature_labels):
         params = nature_params[label][col]
-        s_seq = np.random.beta(params[0], params[1], (1000, 200))
+        s_seq = rng.beta(params[0], params[1], (1000, 200))
         _, c1 = simulate_blume_easley(s_seq, f_belief, g_belief, λ)
         
         median_c1 = np.median(c1, axis=0)
@@ -1120,11 +1122,13 @@ We'll  start with different initial priors $\pi^i_0 \in (0, 1)$ and widen the ga
 Now we can run simulations for different scenarios
 
 ```{code-cell} ipython3
+rng = np.random.default_rng()
+
 # Nature follows f
-s_seq_f = np.random.beta(F_a, F_b, (N, T))
+s_seq_f = rng.beta(F_a, F_b, (N, T))
 
 # Nature follows g
-s_seq_g = np.random.beta(G_a, G_b, (N, T)) 
+s_seq_g = rng.beta(G_a, G_b, (N, T)) 
 
 results_f = {}
 results_g = {}
@@ -1241,6 +1245,8 @@ Here is one solution
 T = 40
 N = 1000
 
+rng = np.random.default_rng()
+
 F_a, F_b = 2, 5
 G_a, G_b = 5, 2
 
@@ -1253,8 +1259,8 @@ g = jit(lambda x: p(x, G_a, G_b))
     (0.1, 0.9),
 ]
 
-s_seq_f = np.random.beta(F_a, F_b, (N, T))
-s_seq_g = np.random.beta(G_a, G_b, (N, T)) 
+s_seq_f = rng.beta(F_a, F_b, (N, T))
+s_seq_g = rng.beta(G_a, G_b, (N, T)) 
 
 results_f = {}
 results_g = {}
@@ -1586,9 +1592,11 @@ In the simulation below, agent 1 assigns positive probabilities only to $f$ and 
 T = 100
 N = 1000
 
+rng = np.random.default_rng()
+
 # Generate sequences for nature f and g
-s_seq_f = np.random.beta(F_a, F_b, (N, T))
-s_seq_g = np.random.beta(G_a, G_b, (N, T))
+s_seq_f = rng.beta(F_a, F_b, (N, T))
+s_seq_g = rng.beta(G_a, G_b, (N, T))
 
 # Run simulations
 results_f = simulate_three_model_allocation(s_seq_f, 
@@ -1712,9 +1720,11 @@ Now we can run the simulation
 T = 1000
 N = 1000
 
+rng = np.random.default_rng()
+
 # Generate sequences for different nature scenarios
-s_seq_f = np.random.beta(F_a, F_b, (N, T))
-s_seq_g = np.random.beta(G_a, G_b, (N, T))
+s_seq_f = rng.beta(F_a, F_b, (N, T))
+s_seq_g = rng.beta(G_a, G_b, (N, T))
 
 # Run simulations for both scenarios
 results_f = simulate_three_model_allocation(


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `likelihood_ratio_process_2.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

All `np.random.*` draws are replaced with an explicit `rng = np.random.default_rng()`.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open issue concerns it, and the only open PR that touches the file ([#651](https://github.com/QuantEcon/lecture-python.myst/pull/651), a `likelihood_bayes` style-guide PR) changes a single unrelated prose line — nothing overlaps with this migration.

## Details

- In the main text, `rng` is defined once in the imports cell and reused in the later main-text cells.
- Each solution block (`lr_ex4`, `lr_ex5`, `lr_ex6`, `lr_ex7`) defines its own `rng` so the block stays self-contained.
- Replacements: `np.random.beta(...)` → `rng.beta(...)`, and `np.random.rand(N, T)` → `rng.random((N, T))` (note the shape tuple).
- No fixed seed is introduced, since the lecture did not seed before.

**Numba notes.** The two `@jit(parallel=True)` functions (`compute_posterior_three_models`, `simulate_three_model_allocation`) take pre-generated `s_seq` arrays as input and do **not** draw random numbers inside their `prange` loops, so no random draws occur inside the parallel loops.

The one jitted draw is in `simulate` (`@jit`), migrated by passing `rng` in as an explicit argument (`w = rng.beta(a, b)`). Note that `simulate` is **not called anywhere in this lecture**, so it is never compiled — the build therefore does not exercise that particular line. Flagging for reviewer judgment.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
