### PR TITLE
[eig_circulant.md] Update np.random → Generator API

### DIFF
--- a/lectures/eig_circulant.md
+++ b/lectures/eig_circulant.md
@@ -380,7 +380,8 @@ and that every eigenvector of $P$ is also an eigenvector of $C$.
 We illustrate this for $N=8$ case.
 
 ```{code-cell} ipython3
-c = np.random.random(8)
+rng = np.random.default_rng()
+c = rng.random(8)
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `eig_circulant.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The single `np.random.random(...)` draw is replaced with an explicit `rng = np.random.default_rng()`.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR touches it, and the only related issue ([#512](https://github.com/QuantEcon/lecture-python.myst/issues/512)) is a title-formatting tracking issue unrelated to this migration.

## Details

- `np.random.random(8)` → `rng.random(8)`, with `rng = np.random.default_rng()` defined at the point of use in the main text.
- No fixed seed is introduced, since the lecture did not seed before.
- The lecture contains no Numba/`@jit` code, so there are no parallel-RNG concerns.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
