### PR TITLE
[os_egm.md] Update np.random → Generator API

### DIFF
--- a/lectures/os_egm.md
+++ b/lectures/os_egm.md
@@ -210,8 +210,8 @@ def create_model(
     s_grid = np.linspace(1e-4, grid_max, grid_size)
 
     # Store shocks (with a seed, so results are reproducible)
-    np.random.seed(seed)
-    shocks = np.exp(μ + ν * np.random.randn(shock_size))
+    rng = np.random.default_rng(seed)
+    shocks = np.exp(μ + ν * rng.standard_normal(shock_size))
 
     return Model(
         u, f, β, μ, ν, s_grid, shocks, α, u_prime, f_prime, u_prime_inv


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `os_egm.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The seeded `np.random.seed(...)` / `np.random.randn(...)` pattern in `create_model` is replaced with an explicit seeded generator `rng = np.random.default_rng(seed)`.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR touches it and no open issue concerns it — nothing overlaps with this migration.

## Details

- In `create_model`, `np.random.seed(seed)` + `np.random.randn(shock_size)` → `rng = np.random.default_rng(seed)` + `rng.standard_normal(shock_size)`.
- The existing fixed seed (`1234`) is kept, since the lecture already seeded for reproducibility. `rng` is local to `create_model`, so no hidden global random state remains.
- The lecture has no `@jit`/`prange` code. (This is the NumPy version; the JAX version lives in `os_egm_jax`.)

## Note for reviewers

`default_rng` produces a different stream from the legacy `RandomState`, so the same seed gives different draws. The figures are unchanged; only the printed numbers shift slightly.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
