### PR TITLE
[qr_decomp.md] Update np.random → Generator API

### DIFF
--- a/lectures/qr_decomp.md
+++ b/lectures/qr_decomp.md
@@ -169,6 +169,8 @@ Now let's write some homemade Python code to implement a QR decomposition by dep
 ```{code-cell} ipython3
 import numpy as np
 from scipy.linalg import qr
+
+rng = np.random.default_rng()
 ```
 
 ```{code-cell} ipython3
@@ -354,7 +356,7 @@ Here goes
 
 ```{code-cell} ipython3
 # experiment this with one random A matrix
-A = np.random.random((3, 3))
+A = rng.random((3, 3))
 ```
 
 ```{code-cell} ipython3
@@ -396,14 +398,14 @@ k = 5
 n = 1000
 
 # generate some random moments
-𝜇 = np.random.random(size=k)
-C = np.random.random((k, k))
+𝜇 = rng.random(size=k)
+C = rng.random((k, k))
 Σ = C.T @ C
 ```
 
 ```{code-cell} ipython3
 # X is random matrix where each column follows multivariate normal dist.
-X = np.random.multivariate_normal(𝜇, Σ, size=n)
+X = rng.multivariate_normal(𝜇, Σ, size=n)
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `qr_decomp.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The four module-level `np.random.*` calls are replaced with calls on an explicit generator `rng = np.random.default_rng()`, defined once in the lecture's import cell and reused throughout.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `qr_decomp.md`. The one related issue is #582, on seeding lectures with stochastic output — see the note for reviewers below.

## Details

- `rng = np.random.default_rng()` added to the import cell (`import numpy as np` / `from scipy.linalg import qr`).
- `np.random.random(...)` → `rng.random(...)` in the QR eigenvalue experiment and in the PCA section's random moments.
- `np.random.multivariate_normal(...)` → `rng.multivariate_normal(...)`.
- No fixed seed was introduced, since the lecture did not seed before.
- No prose changes were needed: the text does not refer to `np.random` as a module-level function, and the displayed results are eigenvalue comparisons and `np.abs(...).max()` residuals rather than specific realized draws.
- The lecture contains no Numba (`@jit`, `@njit`, `@jitclass`, `parallel=True`, `prange`) code.
- A full local build completed successfully and `qr_decomp.md` executed without errors.

## Note for reviewers

This lecture produces stochastic output and has never set a seed, which is the situation tracked in #582. I have kept it unseeded here to stay within the scope of the API migration, but please feel free to add a seed as part of that issue if you would prefer.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
