### PR TITLE
[samuelson.md] Update np.random → Generator API

### DIFF
--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -606,8 +606,8 @@ def simulate_samuelson(
     
     # Generate shocks if stochastic
     if σ > 0:
-        np.random.seed(seed)
-        ϵ = np.random.normal(0, 1, n)
+        rng = np.random.default_rng(seed)
+        ϵ = rng.normal(0, 1, n)
     
     # Simulate forward
     for t in range(2, n):
@@ -1190,7 +1190,8 @@ C[1] = σ  # Shock variance
 
 sam_t = LinearStateSpace(A, C, G, mu_0=μ_0)
 
-x, y = sam_t.simulate(ts_length=n)
+rng = np.random.default_rng()
+x, y = sam_t.simulate(ts_length=n, random_state=rng)
 
 fig, axes = plt.subplots(3, 1, sharex=True, figsize=(12, 8))
 titles = ["Output ($Y_t$)", "Consumption ($C_t$)", "Investment ($I_t$)"]
@@ -1303,8 +1304,8 @@ class SamuelsonLSS(LinearStateSpace):
             except ValueError:
                 print("Stationary distribution does not exist")
 
-        np.random.seed(seed)
-        x, y = self.simulate(ts_length)
+        rng = np.random.default_rng(seed)
+        x, y = self.simulate(ts_length, random_state=rng)
 
         fig, axes = plt.subplots(3, 1, sharex=True, figsize=(12, 8))
         titles = ["Output ($Y_t$)", 


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `samuelson.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The lecture's uses of `np.random.seed(...)` are replaced with an explicit seeded generator `rng = np.random.default_rng(seed)`, and the one remaining call that relied on NumPy's global state is given an explicit generator too.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `samuelson.md`. Issue #579 (a `matplotlib` deprecation warning in this lecture, also reported by #587) concerns a different part of the file, and this PR does not attempt to address it.

## Details

- In `simulate_samuelson`, `np.random.seed(seed)` + `np.random.normal(0, 1, n)` → `rng = np.random.default_rng(seed)` + `rng.normal(0, 1, n)`.
- In `SamuelsonLSS.plot_simulation`, `np.random.seed(seed)` was seeding NumPy's global state so that the inherited `LinearStateSpace.simulate` would be reproducible. It now creates a local generator and passes it in: `self.simulate(ts_length, random_state=rng)`. `LinearStateSpace.simulate` takes a `random_state` argument and accepts a `Generator`.
- The `sam_t.simulate(ts_length=n)` call in "Using the `LinearStateSpace` class" passed no `random_state` and so drew from NumPy's global singleton. It is now given an explicit generator as well. That call was not seeded before and is not seeded now, so its output is as reproducible as it was.
- The existing seeds (`42` at the call sites, `0` as the method default) are kept, and no new seed was introduced.
- After these changes the lecture no longer reads or writes NumPy's global random state.
- No prose changes were needed: the text does not refer to `np.random`, and it does not describe specific realized paths.
- The lecture contains no Numba (`@jit`, `@njit`, `@jitclass`, `parallel=True`, `prange`) code.
- A full local build completed successfully and `samuelson.md` executed without errors.

## Note for reviewers

This migration changes some of the figures: the shocks are plotted directly as simulated paths, so a different stream gives different lines even with the seeds unchanged. I checked the rebuilt lecture and each figure still shows the behaviour it is meant to illustrate.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
