### PR TITLE
[svd_intro.md] Update np.random → Generator API

### DIFF
--- a/lectures/svd_intro.md
+++ b/lectures/svd_intro.md
@@ -280,6 +280,8 @@ Let's do an example.
 import numpy as np
 import numpy.linalg as LA
 import matplotlib.pyplot as plt
+
+rng = np.random.default_rng()
 ```
 
 Having imported these modules, let's do the example.
@@ -424,7 +426,7 @@ First, let's study a case in which $m = 5 > n = 2$.
 
 ```{code-cell} ipython3
 import numpy as np
-X = np.random.rand(5,2)
+X = rng.random((5, 2))
 U, S, V = np.linalg.svd(X,full_matrices=True)  # full SVD
 Uhat, Shat, Vhat = np.linalg.svd(X,full_matrices=False) # economy SVD
 print('U, S, V =')
@@ -486,7 +488,7 @@ To illustrate this case,  we'll set $m = 2 < 5 = n $ and compute both full and r
 
 ```{code-cell} ipython3
 import numpy as np
-X = np.random.rand(2,5)
+X = rng.random((2, 5))
 U, S, V = np.linalg.svd(X,full_matrices=True)  # full SVD
 Uhat, Shat, Vhat = np.linalg.svd(X,full_matrices=False) # economy SVD
 print('U, S, V = ')


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `svd_intro.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The two `np.random.rand(...)` calls are replaced with calls on an explicit generator `rng = np.random.default_rng()`, defined once in the lecture's import cell.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `svd_intro.md`, and no open issue concerns this migration.

## Details

- `rng = np.random.default_rng()` added to the import cell.
- `np.random.rand(5, 2)` → `rng.random((5, 2))` and `np.random.rand(2, 5)` → `rng.random((2, 5))`, in the two cells that build a random matrix `X` for the full-versus-reduced SVD comparison.
- No fixed seed was introduced, since the lecture did not seed before.
- No prose changes were needed: the text does not refer to `np.random`, and the discussion is about the shapes of `U`, `S` and `V` rather than the realized entries of `X`.
- The lecture contains no Numba (`@jit`, `@njit`, `@jitclass`, `parallel=True`, `prange`) code.
- A full local build completed successfully and `svd_intro.md` executed without errors.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
