### PR TITLE
[theil_2.md] Update np.random → Generator API

### DIFF
--- a/lectures/theil_2.md
+++ b/lectures/theil_2.md
@@ -642,7 +642,7 @@ mystnb:
     caption: Standard vs robust consumption paths
     name: fig-std-vs-robust-paths
 ---
-np.random.seed(0)
+rng = np.random.default_rng(0)
 T_sim = 100
 
 def simulate_ar1(φ, ν, shocks, mu0=0.0):
@@ -652,7 +652,7 @@ def simulate_ar1(φ, ν, shocks, mu0=0.0):
         path[t] = φ * path[t-1] + ν * ε
     return path
 
-shock_path = np.random.randn(T_sim - 1)
+shock_path = rng.standard_normal(T_sim - 1)
 mu0_init = 10.0
 mu_std_path = simulate_ar1(φ_std, ν_std, shock_path, mu0=mu0_init)
 mu_rob_path = simulate_ar1(φ_rob, ν_rob, shock_path, mu0=mu0_init)


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `theil_2.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The seeded `np.random.seed(...)` / `np.random.randn(...)` pattern in the cell that plots standard against robust consumption paths is replaced with an explicit seeded generator `rng = np.random.default_rng(0)`.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `theil_2.md`. Issue #990 lists `theil_2.md` among the lectures with dangling citation keys, but the fix there is to `quant-econ.bib` rather than to this file, and this PR does not attempt to address it.

## Details

- `np.random.seed(0)` → `rng = np.random.default_rng(0)`, and `np.random.randn(T_sim - 1)` → `rng.standard_normal(T_sim - 1)`.
- The existing seed (`0`) is kept, and `rng` is local to the cell that uses it, so no hidden global random state remains.
- Both panels of the figure continue to share the same `shock_path`, so the comparison between the standard and robust policies is unaffected.
- No prose changes were needed: the text does not refer to `np.random`, and it describes the paths qualitatively rather than by their realized values.
- The lecture contains no Numba (`@jit`, `@njit`, `@jitclass`, `parallel=True`, `prange`) code.
- A full local build completed successfully and `theil_2.md` executed without errors.

## Note for reviewers

The figure changes: `default_rng` draws from a different stream than the legacy API, so the same seed gives different draws. The rebuilt figure shows the same pattern as the current one.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
