### PR TITLE
[FIX] Add pip install cells for quantecon and jax in lectures that were missing them

### DIFF
--- a/lectures/career.md
+++ b/lectures/career.md
@@ -36,7 +36,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!pip install quantecon
+!pip install quantecon jax
 ```
 
 ## Overview

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -32,7 +32,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!pip install quantecon
+!pip install quantecon jax
 ```
 
 ## Overview

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -28,6 +28,14 @@ kernelspec:
 :depth: 2
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install jax
+```
+
 ## Overview
 
 In this lecture, we will study the time path of inventories for firms that

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -30,6 +30,14 @@ kernelspec:
 ```{include} _admonition/gpu.md
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install jax
+```
+
 ## Overview
 
 In this section, we solve a simple on-the-job search model

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -36,7 +36,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install --upgrade quantecon yfinance
+!pip install --upgrade quantecon yfinance jax
 ```
 
 ## Overview

--- a/lectures/learning_approximation.md
+++ b/lectures/learning_approximation.md
@@ -29,6 +29,14 @@ kernelspec:
 :depth: 2
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install quantecon
+```
+
 ## Overview
 
 In {doc}`olg_adaptive_money` a system of adaptive agents found a rational expectations

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -28,6 +28,14 @@ kernelspec:
 :depth: 2
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install jax
+```
+
 ## Overview
 
 In {doc}`ols`, we estimated the relationship between

--- a/lectures/newton_method.md
+++ b/lectures/newton_method.md
@@ -31,6 +31,14 @@ kernelspec:
 :depth: 2
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install jax
+```
+
 ## Overview
 
 Many economic problems involve finding [fixed

--- a/lectures/olg_adaptive_money.md
+++ b/lectures/olg_adaptive_money.md
@@ -29,6 +29,14 @@ kernelspec:
 :depth: 2
 ```
 
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython3
+:tags: [hide-output]
+
+!pip install quantecon
+```
+
 ## Overview
 
 {doc}`bounded_rationality` presented some models of monetary economies with multiple rational expectations equilibria.


### PR DESCRIPTION
This PR adds pip install cells for quantecon and jax in lectures that were missing them.