### PR TITLE
[uncertainty_traps.md] Update np.random → Generator API

### DIFF
--- a/lectures/uncertainty_traps.md
+++ b/lectures/uncertainty_traps.md
@@ -278,15 +278,15 @@ class UncertaintyTrapEcon:
         """
         self.θ = self.ρ * self.θ + self.σ_θ * w
 
-    def gen_aggregates(self):
+    def gen_aggregates(self, rng):
         """
         Generate aggregates based on current beliefs (μ, γ). This
         is a simulation step that depends on the draws for F.
         """
-        F_vals = self.σ_F * np.random.randn(self.num_firms)
+        F_vals = self.σ_F * rng.standard_normal(self.num_firms)
         M = np.sum(self.ψ(F_vals) > 0)  # Counts number of active firms
         if M > 0:
-            x_vals = self.θ + self.σ_x * np.random.randn(M)
+            x_vals = self.θ + self.σ_x * rng.standard_normal(M)
             X = x_vals.mean()
         else:
             X = 0
@@ -444,10 +444,11 @@ M_vec = np.empty(sim_length)
 γ_vec[0] = econ.γ
 θ_vec[0] = 0
 
-w_shocks = np.random.randn(sim_length)
+rng = np.random.default_rng()
+w_shocks = rng.standard_normal(sim_length)
 
 for t in range(sim_length-1):
-    X, M = econ.gen_aggregates()
+    X, M = econ.gen_aggregates(rng)
     X_vec[t] = X
     M_vec[t] = M
 
@@ -459,7 +460,7 @@ for t in range(sim_length-1):
     θ_vec[t+1] = econ.θ
 
 # Record final values of aggregates
-X, M = econ.gen_aggregates()
+X, M = econ.gen_aggregates(rng)
 X_vec[-1] = X
 M_vec[-1] = M
 ```


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `uncertainty_traps.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The three `np.random.randn(...)` calls are replaced with draws from an explicit generator `rng = np.random.default_rng()`, which is created in the solution block and passed into `gen_aggregates`.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `uncertainty_traps.md`, and no open issue concerns this migration.

## Details

- `UncertaintyTrapEcon.gen_aggregates` now takes `rng` as an argument, and its two draws use `rng.standard_normal(...)`.
- In the solution to Exercise 2, `rng = np.random.default_rng()` is created before the simulation loop, `np.random.randn(sim_length)` → `rng.standard_normal(sim_length)`, and the two `econ.gen_aggregates()` call sites pass `rng`.
- The whole lecture now draws from that single generator, so no hidden global random state remains.
- No fixed seed was introduced, since the lecture did not seed before. The lecture already tells the reader that the output varies from run to run.
- The lecture contains no Numba (`@jit`, `@njit`, `@jitclass`, `parallel=True`, `prange`) code.
- A full local build completed successfully and `uncertainty_traps.md` executed without errors.

## Note for reviewers

`gen_aggregates` now takes `rng` as an argument, so its two call sites changed as well. Happy to give the class its own generator instead if you would rather keep the signature unchanged.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
