### PR TITLE
[rs_inventory_q.md] Update np.random → Generator API

### DIFF
--- a/lectures/rs_inventory_q.md
+++ b/lectures/rs_inventory_q.md
@@ -332,13 +332,12 @@ We simulate inventory dynamics under the optimal policy for the baseline $\gamma
 
 ```{code-cell} ipython3
 @numba.jit(nopython=True)
-def sim_inventories(ts_length, σ, p, X_init=0, seed=0):
+def sim_inventories(ts_length, σ, p, rng, X_init=0):
     """Simulate inventory dynamics under policy σ."""
-    np.random.seed(seed)
     X = np.zeros(ts_length, dtype=np.int32)
     X[0] = X_init
     for t in range(ts_length - 1):
-        d = np.random.geometric(p) - 1
+        d = rng.geometric(p) - 1
         X[t+1] = max(X[t] - d, 0) + σ[X[t]]
     return X
 ```
@@ -354,7 +353,8 @@ K = len(x_values) - 1
 
 for i, γ in enumerate(γ_values):
     v, σ = results[γ]
-    X = sim_inventories(ts_length, σ, model.p, X_init=K // 2, seed=sim_seed)
+    X = sim_inventories(ts_length, σ, model.p,
+                        np.random.default_rng(sim_seed), X_init=K // 2)
     axes[i].plot(X, alpha=0.7)
     axes[i].set_ylabel("inventory")
     axes[i].set_title(f"$\\gamma = {γ}$")
@@ -588,8 +588,7 @@ the update target uses $\exp(-\gamma R_{t+1})
 ```{code-cell} ipython3
 @numba.jit(nopython=True)
 def q_learning_rs_kernel(K, p, c, κ, β, γ, n_steps, X_init,
-                         ε_init, ε_min, ε_decay, q_init, snapshot_steps, seed):
-    np.random.seed(seed)
+                         ε_init, ε_min, ε_decay, q_init, snapshot_steps, rng):
     q = np.full((K + 1, K + 1), q_init)  # optimistic initialization
     n = np.zeros((K + 1, K + 1))        # visit counts for learning rate
     ε = ε_init
@@ -600,7 +599,7 @@ def q_learning_rs_kernel(K, p, c, κ, β, γ, n_steps, X_init,
 
     # Initialize state and action
     x = X_init
-    a = np.random.randint(0, K - x + 1)
+    a = rng.integers(0, K - x + 1)
 
     for t in range(n_steps):
         # Record policy snapshot if needed
@@ -609,7 +608,7 @@ def q_learning_rs_kernel(K, p, c, κ, β, γ, n_steps, X_init,
             snap_idx += 1
 
         # === Draw D_{t+1} and observe outcome ===
-        d = np.random.geometric(p) - 1
+        d = rng.geometric(p) - 1
         reward = min(x, d) - c * a - κ * (a > 0)
         x_next = max(x - d, 0) + a
 
@@ -630,8 +629,8 @@ def q_learning_rs_kernel(K, p, c, κ, β, γ, n_steps, X_init,
 
         # === Behavior policy: ε-greedy (uses a_next, the argmin action) ===
         x = x_next
-        if np.random.random() < ε:
-            a = np.random.randint(0, K - x + 1)
+        if rng.random() < ε:
+            a = rng.integers(0, K - x + 1)
         else:
             a = a_next
         ε = max(ε_min, ε * ε_decay)
@@ -649,8 +648,9 @@ def q_learning_rs(model, n_steps=20_000_000, X_init=0,
     K = len(x_values) - 1
     if snapshot_steps is None:
         snapshot_steps = np.array([], dtype=np.int64)
+    rng = np.random.default_rng(seed)
     return q_learning_rs_kernel(K, p, c, κ, β, γ, n_steps, X_init,
-                                ε_init, ε_min, ε_decay, q_init, snapshot_steps, seed)
+                                ε_init, ε_min, ε_decay, q_init, snapshot_steps, rng)
 ```
 
 ### Running Q-learning
@@ -721,7 +721,8 @@ X_init = K // 2
 sim_seed = 5678
 
 # Optimal policy
-X_opt = sim_inventories(ts_length, σ_star, model.p, X_init, seed=sim_seed)
+X_opt = sim_inventories(ts_length, σ_star, model.p,
+                        np.random.default_rng(sim_seed), X_init)
 axes[0].plot(X_opt, alpha=0.7)
 axes[0].set_ylabel("inventory")
 axes[0].set_title("Optimal (VFI)")
@@ -730,7 +731,8 @@ axes[0].set_ylim(0, K + 2)
 # Q-learning snapshots
 for i in range(n_snaps):
     σ_snap = snapshots[i]
-    X = sim_inventories(ts_length, σ_snap, model.p, X_init, seed=sim_seed)
+    X = sim_inventories(ts_length, σ_snap, model.p,
+                        np.random.default_rng(sim_seed), X_init)
     axes[i + 1].plot(X, alpha=0.7)
     axes[i + 1].set_ylabel("inventory")
     axes[i + 1].set_title(f"Step {snap_steps[i]:,}")


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `rs_inventory_q.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

All of the random draws happen inside `@numba.jit(nopython=True)` functions, so the two of them now take a `rng` argument and the generator is built by the calling Python code.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `rs_inventory_q.md`. Issue #882 concerns the convergence message and the snapshot timing in the Q-learning loop, and this PR does not attempt to address it.

## Details

- `sim_inventories` takes `rng` in place of `seed`, and draws with `rng.geometric(p)`.
- `q_learning_rs_kernel` takes `rng` in place of `seed`, and draws with `rng.geometric(p)`, `rng.integers(...)` and `rng.random()`.
- The `q_learning_rs` wrapper is ordinary Python, so it keeps its `seed=1234` argument and builds the generator itself. Its call site is unchanged.
- The existing seeds (`0`, `1234`, `5678`) are all kept, and no new seed was introduced.
- Both simulation figures build a fresh `np.random.default_rng(sim_seed)` for each call, so the panels still face the same demand sequence, as they did when each call re-seeded. This matters for the figure comparing risk sensitivities and for the figure comparing the Q-learning snapshots against the VFI policy.
- Numba supports `geometric`, `integers` and `random` on a `Generator` passed in as an argument, but does not support constructing one inside a jitted function, which is why the generator is built by the caller. There is no `prange` or `parallel=True` in this lecture, so a single generator is safe here.
- No prose changes were needed.
- A full local build completed successfully and `rs_inventory_q.md` executed without errors.

## Note for reviewers

Both jitted functions take `rng` in place of `seed`, which changes their signatures. `q_learning_rs` keeps its `seed` argument so the call in the lecture is unchanged, but `sim_inventories` is called directly and now receives a generator at each call site.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
