### PR TITLE
[organization_capital.md] Update np.random → Generator API

### DIFF
--- a/lectures/organization_capital.md
+++ b/lectures/organization_capital.md
@@ -188,13 +188,13 @@ mystnb:
     caption: Posterior mean convergence and uncertainty
     name: fig-posterior-evolution
 ---
-np.random.seed(0)
+rng = np.random.default_rng(0)
 
 θ_true = 0.8
 π = 1.0
 
 T = 20
-ε = np.random.randn(T)
+ε = rng.standard_normal(T)
 z_signals = θ_true + ε
 
 posterior_means = []


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `organization_capital.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

The lecture already builds a seeded generator in its four simulation functions. This PR brings the one remaining cell, which still used `np.random.seed(...)` and `np.random.randn(...)`, into line with them.

## Related PRs and issues

I checked for open PRs and issues related to this lecture. No open PR modifies `organization_capital.md`, and no open issue concerns this migration.

While checking the rebuilt figure I did notice that the posterior-mean panel does not show the convergence the text describes. That is pre-existing, and I have filed it separately as #1015.

## Details

- In the cell that plots the posterior evolution, `np.random.seed(0)` → `rng = np.random.default_rng(0)` and `np.random.randn(T)` → `rng.standard_normal(T)`.
- The existing seed (`0`) is kept, and no new seed was introduced.
- The four existing `rng = np.random.default_rng(seed)` calls elsewhere in the lecture are unchanged.
- No prose changes were needed. The text describes the figure qualitatively: the posterior mean converges to the true value and the posterior uncertainty shrinks at rate 1/sqrt(n).
- The lecture contains no Numba (`@jit`, `@njit`, `@jitclass`, `parallel=True`, `prange`) code.
- A full local build completed successfully and `organization_capital.md` executed without errors.

## Note for reviewers

Only the left panel of the posterior figure changes: the posterior standard deviation plotted on the right does not depend on the draws.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
