### PR TITLE
[ifp_advanced] Align K with the (c, a) convention used across the EGM lectures

### DIFF
--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -388,8 +388,8 @@ Here's the Coleman-Reffett operator using JAX:
 
 ```{code-cell} ipython3
 def K(
-        a_in: jnp.array,   # a_in[i, z] is an asset grid
         c_in: jnp.array,   # c_in[i, z] = consumption at a_in[i, z]
+        a_in: jnp.array,   # a_in[i, z] is an asset grid
         ifp: IFP
     ):
     """
@@ -430,7 +430,7 @@ def K(
     c_out = c_out.at[0, :].set(0)
     a_out = a_out.at[0, :].set(0)
 
-    return a_out, c_out
+    return c_out, a_out
 ```
 
 The next function solves for an approximation of the optimal consumption policy
@@ -487,15 +487,15 @@ a_init = σ_init.copy()
 Let's generate an approximation solution with JAX:
 
 ```{code-cell} ipython3
-a_star, σ_star = solve_model(ifp, a_init, σ_init)
+σ_star, a_star = solve_model(ifp, σ_init, a_init)
 ```
 
 Let's try it again with a timer.
 
 ```{code-cell} python3
 with qe.Timer(precision=8):
-    a_star, σ_star = solve_model(ifp, a_init, σ_init)
-    a_star.block_until_ready()
+    σ_star, a_star = solve_model(ifp, σ_init, a_init)
+    σ_star.block_until_ready()
 ```
 
 ## Simulation
@@ -642,7 +642,7 @@ s_grid = ifp.s_grid
 n_z = len(ifp.P)
 a_init = s_grid[:, None] * jnp.ones(n_z)
 c_init = a_init
-a_vec, c_vec = solve_model(ifp, a_init, c_init)
+c_vec, a_vec = solve_model(ifp, c_init, a_init)
 assets = compute_asset_stationary(c_vec, a_vec, ifp, num_households=200_000)
 
 # Compute Gini coefficient for the plot
@@ -734,8 +734,8 @@ for a_r in a_r_vals:
     n_z_temp = len(ifp_temp.P)
     a_init_temp = s_grid_temp[:, None] * jnp.ones(n_z_temp)
     c_init_temp = a_init_temp
-    a_vec_temp, c_vec_temp = solve_model(
-        ifp_temp, a_init_temp, c_init_temp
+    c_vec_temp, a_vec_temp = solve_model(
+        ifp_temp, c_init_temp, a_init_temp
     )
 
     # Simulate households
@@ -811,8 +811,8 @@ for a_y in a_y_vals:
     n_z_temp = len(ifp_temp.P)
     a_init_temp = s_grid_temp[:, None] * jnp.ones(n_z_temp)
     c_init_temp = a_init_temp
-    a_vec_temp, c_vec_temp = solve_model(
-        ifp_temp, a_init_temp, c_init_temp
+    c_vec_temp, a_vec_temp = solve_model(
+        ifp_temp, c_init_temp, a_init_temp
     )
 
     # Simulate households


### PR DESCRIPTION
Follow-up to #762, which is now closed. That PR read the symptom correctly but fixed the wrong end of it; this one fixes the actual defect and is verified by execution.

## What is wrong

`K` in `ifp_advanced.md` is written as `K(a_in, c_in, ifp) -> (a_out, c_out)`, but `solve_model` — copied verbatim from `ifp_egm.md` — calls it as `c_out, a_out = K(c_in, a_in, ifp)`. That is a swap on both the arguments and the unpacking, so the two cancel and the code is numerically correct. What it is not is readable: every name in `solve_model` ends up meaning the opposite of what it says. Its first parameter is documented as `c_init: Initial guess of σ` but is really the asset grid, and its first return value is the asset grid too. A student comparing the signature at line 441 against the call site at line 490 sees a flat contradiction, in a lecture whose entire point is that the source is read.

`ifp_advanced.md` is the only lecture in the family with this inversion. Both `ifp_egm.md` and `ifp_egm_transient_shocks.md` define `K(c_in, a_in, ifp) -> (c_out, a_out)`, and their `solve_model` is otherwise byte-identical to this one. This lecture&apos;s own `simulate_household` and `compute_asset_stationary` also already take `(c_vec, a_vec)` in that order.

## The fix

Swap `K`&apos;s first two parameters and its return order so it matches its siblings, leaving `solve_model` untouched, then update the five call sites to the `(c, a)` ordering everything else already uses. Ten lines, no change to any computation.

## Verification

Executed the lecture end to end on jax 0.11.0 and diffed against `main`:

| quantity | main | this branch |
|---|---|---|
| Gini coefficient | 0.918535 | 0.918532 |
| top 1% wealth share | 0.8982 | 0.8982 |
| median / p99 / min | — | identical |
| policy arrays | — | agree to 2.3e-05 |

Both display as `0.9185` in the lecture output, so nothing visible moves.

The 2.3e-05 residual is a side benefit rather than drift, and it is worth recording. `solve_model` measures convergence as `max|c_out - c_in|`. On `main` that expression landed on the *asset grid*, so it evaluated `(s + c_out) - (s + c_in)` in float32 — a cancellation whose granularity is one ulp of the grid maximum, which at `s = 100` is exactly `7.629395e-06` against a tolerance of `1e-05`. The stopping rule was measuring round-off, and `main`&apos;s reported final error is precisely that ulp. Measuring the consumption residual directly is well conditioned; it converges in 158 iterations instead of 160, and the two solutions differ well inside the solver&apos;s own tolerance.

## Why #762 could not be merged

It applied the same five call-site edits without touching `K`, which reverses the x and y arguments of the `jnp.interp` in `simulate_household`. It raises nothing — consumption is monotone, so the interpolation is perfectly happy — it just returns nonsense. Executed, it gives a Gini of **-0.9995** (outside the possible range of the statistic entirely), a mean wealth of -3389 and a minimum of -4.1e+07. Worth flagging as a reminder that a silently-passing notebook is not evidence of a correct one here.