### PR TITLE
CI: gate the first jb build so notebook errors cannot pass green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,18 @@ jobs:
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
+          # This is the FIRST `jb build` in the workflow, and `execute_notebooks: "cache"`
+          # means only the first build actually executes notebooks — the later HTML build
+          # reads the cache. So this is the step where a CellExecutionError surfaces, and
+          # therefore the step that has to gate.
+          #
+          # `set -eo pipefail` is required as well as `-W`: `shell: bash -l {0}` is a
+          # custom shell spec, so GitHub does not inject `-eo pipefail` (it only does
+          # that for the bare `shell: bash` shorthand). Without it a failing `jb build`
+          # would be masked by the trailing mkdir/cp, whose exit code becomes the
+          # step's — and `--keep-going` guarantees the .ipynb files exist for `cp`
+          # to succeed on.
+          set -eo pipefail
           jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
           mkdir -p _build/html/_notebooks
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks


### PR DESCRIPTION
Part of QuantEcon/meta#340.

## The problem

The `Build Download Notebooks (sphinx-tojupyter)` step is the **first** `jb build` in this workflow, and `lectures/_config.yml` sets `execute_notebooks: "cache"` — so it is the only build that actually executes notebooks; the later HTML build reads the cache. That makes it the step where a `CellExecutionError` surfaces.

It could not fail.

The flags were already correct (`-n -W --keep-going`), but inert. The step runs three commands under `shell: bash -l {0}`, and GitHub only injects `-eo pipefail` for the bare `shell: bash` shorthand — an explicit custom shell spec gets neither `-e` nor `-o pipefail`. So a failing `jb build` was followed by `mkdir` and `cp`, and the step exited with `cp`'s status. `--keep-going` makes this worse rather than better: it forces Sphinx to emit output despite the errors, guaranteeing the `.ipynb` files exist for `cp` to succeed on.

## The change

One line — `set -eo pipefail` — plus a comment recording why it is needed and why this step is the one that matters. No flag changes, no `_config.yml` change.

## Note on which step

The rule is **"gate the first `jb build`"**, not "gate a particular step name". Where a repo's `Build PDF from LaTeX` step is active it runs first and is the one to gate (see QuantEcon/lecture-python-intro#809); here the LaTeX step comes later, so the notebooks step is first. The audit table in QuantEcon/meta#340 records which step applies per repo.

## Verified before the change

This repo already uses `raises-exception` tags where cells are meant to error, so nothing is relying on an error being tolerated silently.

Refs QuantEcon/meta#340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
