### PR TITLE
chore(ci): track quantecon/actions at the floating @v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           node-version: '20'
       - name: Preview Deploy to Netlify
-        uses: quantecon/actions/preview-netlify@v0.8.0
+        uses: quantecon/actions/preview-netlify@v0
         with:
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
           path: _build/html/reports
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: quantecon/actions/publish-gh-pages@v0.8.0
+        uses: quantecon/actions/publish-gh-pages@v0
         with:
           build-dir: _build/html
           cname: python.quantecon.org


### PR DESCRIPTION
Moves both `quantecon/actions` call sites from `@v0.8.0` to the floating `@v0`, the reference [CONTRIBUTING recommends](https://github.com/QuantEcon/actions/blob/main/CONTRIBUTING.md#version-tags) for consumers. This is the last QuantEcon repo still on an exact pin.

## This changes almost nothing today

Worth stating plainly, because the diff looks more consequential than it is. Comparing `v0.8.0` against `v0.11.1` for the two actions this repo actually uses:

| Action | Change across the span |
|---|---|
| `preview-netlify` | **none** — byte-for-byte identical |
| `publish-gh-pages` | **one line** — a SHA bump of the third-party `softprops/action-gh-release` |

The only ⚠️ BREAKING change in that span was to `restore-jupyter-cache`, which this repo does not use. So there is no behaviour change to review here and nothing to verify beyond CI staying green.

## Why do it then

The value is entirely prospective, and `lecture-dp` just made the case for it. That repo sat three releases behind on exact pins and ran its unattended weekly cache build for roughly two months with failure alerting that had never worked — because the fix could only arrive by someone remembering to bump a pin. A pin that must be bumped by hand in order to deliver a fix has the same failure mode as the missing fix.

Nothing in this repo is unattended in quite that way, so the risk here is lower. But the drift mechanism is identical, and with the rest of the estate on `@v0` there is no reason to keep the one exception.

The usual counter — `0.x` minors may break — is covered by `test-actions-lecture-intro`, which runs the full chain against `@v0` and meets a bad release first, and by ⚠️ BREAKING markers with migration notes in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)