### PR TITLE
Repoint the ols, mle and phillips data reads to data-lectures (wave B1')

### DIFF
--- a/.github/workflows/data-url-guard.yml
+++ b/.github/workflows/data-url-guard.yml
@@ -1,0 +1,49 @@
+# A dataset read that points at the wrong host fails in the reader's notebook,
+# not in CI. The data-audit dashboard that would catch it lives in
+# QuantEcon/data-lectures, runs on that repo's pushes and a weekly cron, and
+# never on a pull request here — so its detection lag is up to seven days.
+# This is the only check that fires at the moment of the change.
+#
+# It is also the only check here that fires on a PROSE edit. `ci.yml` executes
+# the book, but jupyter-cache hashes code cells only and restores a warm shared
+# cache, so a markdown link or a {download} role that points at a dead URL
+# cache-hits and goes green. Do not read a green `ci.yml` as evidence that a
+# prose link resolves.
+#
+# See QuantEcon/data-lectures PLAN.md, repoint rule 6.
+
+name: Data URL guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  data-url-guard:
+    runs-on: ubuntu-latest
+    # This job greps a checkout and writes nothing. The repo default is
+    # `write`, so without this it would receive a token that can also approve
+    # pull request reviews.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: No data-lectures read on the LFS media host
+        run: |
+          # media.githubusercontent.com is the LFS *media* endpoint and routes
+          # per path: it serves a file only where that path is LFS-tracked in
+          # the repo the URL names, and 404s otherwise. Everything data-lectures
+          # publishes is plain git, so this host never resolves for it — and a
+          # mechanical org/repo swap that preserves the host breaks every read.
+          #
+          # grep -r walks lectures/_static/** too. Nothing under _static is
+          # executed by this repo's build (it is an asset path, and
+          # `only_build_toc_files: true` builds exactly _toc.yml), and the
+          # data-lectures audit excludes _static by design — so a bad URL in a
+          # vendored notebook or script there is invisible everywhere else.
+          if grep -rnF 'media.githubusercontent.com/media/QuantEcon/data-lectures' lectures/; then
+            echo "::error::Read data-lectures over raw.githubusercontent.com (or the github.com/.../raw/ redirect), never media.githubusercontent.com — that host is LFS-only and 404s every file data-lectures publishes."
+            exit 1
+          fi
+          echo "OK — no data-lectures read on the media host."

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -157,13 +157,13 @@ Let's have a look at the distribution of the data we'll be working with in this 
 
 Treisman's main source of data is *Forbes'* annual rankings of billionaires and their estimated net worth.
 
-The dataset `mle/fp.dta` can be downloaded from [here](https://python.quantecon.org/_static/lecture_specific/mle/fp.dta)
+The dataset `fp.dta` can be downloaded from [here](https://github.com/QuantEcon/data-lectures/raw/main/lectures/fp.dta)
 or its [AER page](https://www.aeaweb.org/articles?id=10.1257/aer.p20161068).
 
 ```{code-cell} ipython3
 # Load in data and view
 df = pd.read_stata(
-    "https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/mle/fp.dta"
+    "https://github.com/QuantEcon/data-lectures/raw/main/lectures/fp.dta"
 )
 df.head()
 ```

--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -91,7 +91,7 @@ These variables and other data used in the paper are available for download on D
 We will use pandas' `.read_stata()` function to read in data contained in the `.dta` files to dataframes
 
 ```{code-cell} python3
-df1 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable1.dta')
+df1 = pd.read_stata('https://github.com/QuantEcon/data-lectures/raw/main/lectures/maketable1.dta')
 df1.head()
 ```
 
@@ -323,7 +323,7 @@ Let's estimate some of the extended models considered in the paper
 (Table 2) using data from `maketable2.dta`
 
 ```{code-cell} python3
-df2 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable2.dta')
+df2 = pd.read_stata('https://github.com/QuantEcon/data-lectures/raw/main/lectures/maketable2.dta')
 
 # Add constant term to dataset
 df2['const'] = 1
@@ -475,7 +475,7 @@ used for estimation)
 
 ```{code-cell} python3
 # Import and select the data
-df4 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable4.dta')
+df4 = pd.read_stata('https://github.com/QuantEcon/data-lectures/raw/main/lectures/maketable4.dta')
 df4 = df4[df4['baseco'] == 1]
 
 # Add a constant variable
@@ -603,7 +603,7 @@ results.
 
 ```{code-cell} python3
 # Load in data
-df4 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable4.dta')
+df4 = pd.read_stata('https://github.com/QuantEcon/data-lectures/raw/main/lectures/maketable4.dta')
 
 # Add a constant term
 df4['const'] = 1
@@ -676,7 +676,7 @@ using `numpy` - your results should be the same as those in the
 
 ```{code-cell} python3
 # Load in data
-df1 = pd.read_stata('https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/lectures/_static/lecture_specific/ols/maketable1.dta')
+df1 = pd.read_stata('https://github.com/QuantEcon/data-lectures/raw/main/lectures/maketable1.dta')
 df1 = df1.dropna(subset=['logpgp95', 'avexpr'])
 
 # Add a constant term

--- a/lectures/phillips_drifts_volatilities.md
+++ b/lectures/phillips_drifts_volatilities.md
@@ -99,11 +99,7 @@ from scipy.special import expit
 from scipy.stats import invwishart
 
 
-data_url = (
-    'https://raw.githubusercontent.com/QuantEcon/lecture-python.myst/'
-    'main/lectures/_static/lecture_specific/phillips_drifts_volatilities/'
-    'NEWQDATA.csv'
-)
+data_url = 'https://github.com/QuantEcon/data-lectures/raw/main/lectures/NEWQDATA.csv'
 ```
 
 ## Bad policy or bad luck?


### PR DESCRIPTION
Wave B1′ step 2. Seven code-cell reads across three lectures, plus the prose download link in `mle.md`, now read `QuantEcon/data-lectures` instead of this repo's own committed blobs.

The data landed in QuantEcon/data-lectures#79, which recorded the byte gate: all five files are byte-identical to the copies this repo serves today. **So this repoint provably cannot change a figure or a coefficient** — and reproduced from the new URL, `ols.md`'s headline regression still gives n=111, b0=4.6261, b1=0.5319, R²=0.6113, which is the 4.63 / 0.53 / 0.611 the prose quotes.

**The files under `lectures/_static/lecture_specific/` are deliberately NOT deleted here.** This repo publishes on a `publish*` tag, so the already-published notebooks keep the old URLs until the next publish; deleting now would 404 them for every reader who downloads a lecture or opens it in Colab, and nothing would alert us — rendered HTML is unaffected because figures are baked at build time. Deletion is a follow-up PR gated on the publish.

## What changed

| File | Line | Change |
| --- | --- | --- |
| `ols.md` | 94, 326, 478, 606, 679 | five `read_stata` reads → `maketable1/2/4.dta` |
| `mle.md` | 160 | prose download link → `fp.dta` (see below) |
| `mle.md` | 166 | `read_stata` read → `fp.dta` |
| `phillips_drifts_volatilities.md` | 102-106 → 102 | `data_url` continuation collapsed → `NEWQDATA.csv` |

All reads use the documented CPython form, `https://github.com/QuantEcon/data-lectures/raw/main/lectures/<file>`.

## Three details worth a reviewer's eye

**`mle.md:160` pointed at the published site, not at this repo.** The link was `https://python.quantecon.org/_static/lecture_specific/mle/fp.dta`. That URL survives a repoint and breaks only when the file is deleted and the site republishes — a delayed 404 with no rule covering it. It also named `mle/fp.dta` inline in the sentence, a path that does not exist in the flat published tree, so the filename in the prose is corrected alongside the href.

Note **no automated check in this repo would have caught that link**. `ci.yml` executes the book, but `jupyter-cache` hashes code-cell source only and the workflow restores a warm shared `build-cache` artifact — so a prose-only edit cache-hits, the notebook is never executed, and CI goes green over a dead link. `linkcheck.yml` would report it, but it runs weekly, scans the *published* release archive rather than this branch, and is `fail: false`. Do not read a green CI here as evidence that a prose link resolves.

**`phillips_drifts_volatilities.md` built its URL by string concatenation across three source lines.** The continuation is collapsed to a single line rather than patched in place. Patching only the host line would have left `'NEWQDATA.csv'` appended to a path that no longer exists — the flat published tree has no `_static/lecture_specific/<lecture>/` segment to append it to. This was the only form-B (`raw.githubusercontent.com`) read of the seven.

**`data-url-guard.yml` is added.** This repo lacked it; `lecture-python-intro` and `lecture-wasm` both have it. It greps for `media.githubusercontent.com/media/QuantEcon/data-lectures` — the LFS media endpoint, which routes per path and so 404s everything data-lectures publishes, since that tree is 100% plain git. The risk is specifically a mechanical org/repo swap that preserves the host, which is exactly the shape of this PR's edits. It is a copy of intro's with its comments corrected for this repo: intro's cites `exclude_patterns`, which this repo's `_config.yml` does not define.

## Verification

- All five URLs fetched and read with pandas from the new location — shapes `(163, 13)`, `(163, 9)`, `(163, 10)`, `(5432, 36)`, `(211, 4)`
- `ols.md`'s headline OLS reproduced exactly from the repointed URL (above)
- Grep confirms **zero** surviving references to `_static/lecture_specific/{ols,mle,phillips_drifts_volatilities}`, `lecture-python.myst/raw`, `raw.githubusercontent.com/QuantEcon/lecture-python.myst`, or `python.quantecon.org/_static/lecture_specific/mle` in the three lectures
- The new guard passes against this branch
- `git diff --stat` is 8 insertions / 12 deletions across three `.md` files and **no file deletions** — the committed data files are untouched

## What comes next

1. This merges → the generated `[translation-sync]` PR fires into `lecture-python.zh-cn`. **Hand-diff it before merging** — the sync replaces whole `##` sections through a model and will clobber localisations near the reads.
2. `QuantEcon/lecture-stats` carries the identical `python.quantecon.org/…/fp.dta` prose link at `lectures/mle.md:132` and runs a **daily** linkcheck. Its repoint is part of this wave.
3. `data-lectures` flips to `repointed` and records consumers.
4. Tag a publish here, **then** merge the zh-cn sync PR, **then** tag zh-cn. `lecture-python.notebooks` regenerates ~29 min after this repo's tag.
5. Only then, delete the `_static` copies.

Part of QuantEcon/workspace-lectures#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
