### PR TITLE
Repoint the hansen_singleton pair at QuantEcon/data-lectures (wave B2')

### DIFF
--- a/lectures/hansen_singleton_1982.md
+++ b/lectures/hansen_singleton_1982.md
@@ -985,16 +985,12 @@ Because the Ken French return is not identical to the original CRSP NYSE value-w
 
 Both this lecture and the companion lecture {doc}`hansen_singleton_1983` use the same data construction.
 
-The hidden cell below loads a vendored monthly dataset of gross real returns and gross consumption growth. The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`_static/lecture_specific/hansen_singleton_1982/make_data.py`](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_static/lecture_specific/hansen_singleton_1982/make_data.py) and read here directly from GitHub.
+The hidden cell below loads a monthly dataset of gross real returns and gross consumption growth from [QuantEcon/data-lectures](https://github.com/QuantEcon/data-lectures). The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`builders/hansen_singleton_1982_data.py`](https://github.com/QuantEcon/data-lectures/blob/main/builders/hansen_singleton_1982_data.py) and read here directly from GitHub.
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
 
-DATA_URL = (
-    "https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/"
-    "lectures/_static/lecture_specific/hansen_singleton_1982/"
-    "hansen_singleton_1982_data.csv"
-)
+DATA_URL = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/hansen_singleton_1982_data.csv"
 
 # Read the vendored snapshot once; load_hs_monthly_data just slices it.
 _data = pd.read_csv(DATA_URL, index_col=0, parse_dates=True)
@@ -1004,9 +1000,9 @@ def load_hs_monthly_data(start="1959-02-01", end="1978-12-01"):
     """
     Load the monthly gross real return and gross consumption-growth series.
 
-    The data are a vendored snapshot built by the maintenance script at
-    ``_static/lecture_specific/hansen_singleton_1982/make_data.py``, which
-    constructs them from FRED and the Ken French data library.
+    The data are a snapshot built by the maintenance script at
+    ``builders/hansen_singleton_1982_data.py`` in QuantEcon/data-lectures,
+    which constructs them from FRED and the Ken French data library.
     """
     start = pd.Timestamp(start).to_period("M").to_timestamp("M")
     end = pd.Timestamp(end).to_period("M").to_timestamp("M")

--- a/lectures/hansen_singleton_1982.md
+++ b/lectures/hansen_singleton_1982.md
@@ -992,7 +992,7 @@ The hidden cell below loads a monthly dataset of gross real returns and gross co
 
 DATA_URL = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/hansen_singleton_1982_data.csv"
 
-# Read the vendored snapshot once; load_hs_monthly_data just slices it.
+# Fetch the snapshot once; load_hs_monthly_data just slices it.
 _data = pd.read_csv(DATA_URL, index_col=0, parse_dates=True)
 
 

--- a/lectures/hansen_singleton_1983.md
+++ b/lectures/hansen_singleton_1983.md
@@ -1424,16 +1424,12 @@ While Hansen-Singleton use CRSP value-weighted NYSE returns, we use the Ken Fren
 
 The consumption series is constructed from consumption of nondurables (`ND`) with the nondurables deflator.
 
-The hidden cell below loads a vendored monthly dataset of returns and consumption series. The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`_static/lecture_specific/hansen_singleton_1983/make_data.py`](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_static/lecture_specific/hansen_singleton_1983/make_data.py) and read here directly from GitHub.
+The hidden cell below loads a monthly dataset of returns and consumption series from [QuantEcon/data-lectures](https://github.com/QuantEcon/data-lectures). The data are built from the [FRED](https://fred.stlouisfed.org/) and [Ken French](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) data libraries by the maintenance script at [`builders/hansen_singleton_1983_data.py`](https://github.com/QuantEcon/data-lectures/blob/main/builders/hansen_singleton_1983_data.py) and read here directly from GitHub.
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
 
-DATA_URL = (
-    "https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/"
-    "lectures/_static/lecture_specific/hansen_singleton_1983/"
-    "hansen_singleton_1983_data.csv"
-)
+DATA_URL = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/hansen_singleton_1983_data.csv"
 
 # Read the vendored snapshot once; load_hs_monthly_data just slices it.
 _data = pd.read_csv(DATA_URL, index_col=0, parse_dates=True)
@@ -1445,9 +1441,9 @@ def load_hs_monthly_data(start="1959-02-01", end="1978-12-01"):
     gross consumption growth, gross consumption inflation, per capita real
     consumption, and gross real T-bill return.
 
-    The data are a vendored snapshot built by the maintenance script at
-    ``_static/lecture_specific/hansen_singleton_1983/make_data.py``, which
-    constructs them from FRED and the Ken French data library.
+    The data are a snapshot built by the maintenance script at
+    ``builders/hansen_singleton_1983_data.py`` in QuantEcon/data-lectures,
+    which constructs them from FRED and the Ken French data library.
     """
     start = pd.Timestamp(start).to_period("M").to_timestamp("M")
     end = pd.Timestamp(end).to_period("M").to_timestamp("M")

--- a/lectures/hansen_singleton_1983.md
+++ b/lectures/hansen_singleton_1983.md
@@ -1431,7 +1431,7 @@ The hidden cell below loads a monthly dataset of returns and consumption series 
 
 DATA_URL = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/hansen_singleton_1983_data.csv"
 
-# Read the vendored snapshot once; load_hs_monthly_data just slices it.
+# Fetch the snapshot once; load_hs_monthly_data just slices it.
 _data = pd.read_csv(DATA_URL, index_col=0, parse_dates=True)
 
 


### PR DESCRIPTION
Repoints both `hansen_singleton` lectures at `QuantEcon/data-lectures`, completing wave B2′ of the datasets migration. Mirrors the wave landed in QuantEcon/data-lectures#82. Work plan: QuantEcon/workspace-lectures#39.

**Deletes nothing.** The `_static` copies and their READMEs stay until this has published, per the repoint → publish → delete ordering rule.

## No figure can change

The bytes in `data-lectures` are byte-identical to the copies these lectures read today — verified at the landing PR, and again against `main` just now:

| URL the lecture now reads | HTTP | sha256 | Bytes |
| --- | --- | --- | --- |
| `data-lectures/raw/main/lectures/hansen_singleton_1982_data.csv` | 200 | `3e9d4f37c31dbcab…` | 11,662 |
| `data-lectures/raw/main/lectures/hansen_singleton_1983_data.csv` | 200 | `dc5c1f8dac4b50ab…` | 26,084 |

Both builder links resolve too (`blob/main/builders/hansen_singleton_198{2,3}_data.py`, 200 each), and a never-existed control path on the same host returns 404 — so those 200s are real hits, not a soft-404 page.

## Six edits, and only two of them are code reads

Three per lecture. This is the part worth reviewing carefully, because two of the three break **silently**:

**1. The data URL — collapsed, not patched.** It was a three-line string concatenation:

```python
DATA_URL = (
    "https://github.com/QuantEcon/lecture-python.myst/raw/refs/heads/main/"
    "lectures/_static/lecture_specific/hansen_singleton_1982/"
    "hansen_singleton_1982_data.csv"
)
```

The stem line could not be edited in place. The published tree in `data-lectures` is flat — it has no `_static/lecture_specific/<lecture>/` segment — so patching the stem alone would have left the filename appended to a path that does not exist. Both are now single lines on the bare `main` form.

**2. The prose link to the maintenance script.** It pointed at `_static/lecture_specific/hansen_singleton_1982/make_data.py` in this repo. That builder moved repos *and* was renamed: both files were called `make_data.py`, which works beside their own output where the parent directory supplies the meaning, and collides outright in a flat `builders/` tree. Each took its dataset's stem.

**3. The same builder path, named again in a docstring inside the data cell.** Easy to miss — it is not a link and not a read, just a path in prose that would have quietly become wrong.

Nothing in this repo or anywhere else would have caught edits 2 and 3. `data-url-guard.yml` greps only for the LFS media host. `jupyter-cache` hashes code cells only, so a stale prose link cache-hits and goes green — which is exactly the failure class that made the D2 decision necessary in wave B1′. Both were found by grepping the filename and the URL stem *separately*; a line-based grep for the whole old URL returns a confident zero against the wrapped form.

## Verification

- **Both directions.** No surviving reference to `lecture_specific/hansen_singleton` or `make_data.py` in either lecture (grep exit 1, against a positive control proving the pattern matches when present); all six new references present and correct.
- **Rest of the repo swept.** The only other mentions of these filenames are inside the two `_static/.../README.md` files, which are scheduled for deletion in the follow-up PR along with the CSVs and builders.
- The data cell re-executes on this PR — the `DATA_URL` change alters the cell hash — so CI genuinely exercises the new URL rather than restoring it from cache.

## What follows

1. this PR merges → the `lecture-python.zh-cn` sync PR generates;
2. `migration.yml` flips `landed` → `repointed` in `data-lectures`, recording consumers;
3. publish `lecture-python.myst`, then merge the sync PR, then publish `lecture-python.zh-cn`;
4. deletion of the `_static` copies, builders and READMEs — its own PR, after the publishes.

Note for step 4: deleting these files will not stop the site serving them. `ci.yml` and `publish.yml` restore the weekly `build-cache` artifact and build over it, and Sphinx never prunes removed `_static` assets, so a deletion keeps being served until `cache.yml` rebuilds clean (Mon 03:00 UTC) *and* a publish follows. Verify that deletion against the published URL, never against `main`. See QuantEcon/data-lectures#81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
